### PR TITLE
Add hmpps-auth as a dependency of the app

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,20 @@ services:
     environment:
       - SERVER_PORT=8080
       - SPRING_PROFILES_ACTIVE=dev
+      - HMPPS_AUTH_URL=http://localhost:8080/auth
+
+  hmpps-auth:
+    image: quay.io/hmpps/hmpps-auth:latest
+    networks:
+      - hmpps
+    container_name: hmpps-auth
+    ports:
+      - "9090:8080"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/auth/health"]
+    environment:
+      - SPRING_PROFILES_ACTIVE=dev
+      - APPLICATION_AUTHENTICATION_UI_ALLOWLIST=0.0.0.0/0
 
 networks:
   hmpps:

--- a/scripts/start-local-services.sh
+++ b/scripts/start-local-services.sh
@@ -26,7 +26,7 @@ pushd "${API_DIR}"
 # TODO: uncomment the below when we have some dependency services to fire up...
 # docker compose pull
 # docker compose build
-# docker compose up -d --scale=app=0
+# docker compose up -d --scale=app=0 --scale=hmpps-auth=0
 SPRING_PROFILES_ACTIVE=dev ./gradlew bootRun >>"${API_LOGFILE}" 2>&1 &
 popd
 


### PR DESCRIPTION
Now we're calling out to hmpps-auth, I've added it as a dependency for
the application (in the docker-compose file) and added the needed config
to allow the local docker build to start up (this will be needed for E2E
tests).