### PR TITLE
Docker setup changes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,10 @@
-version: "3"
+version: '3.9'
 services:
-  app:
+  make-recall-decision-api:
     build:
       context: .
+    networks:
+      - hmpps
     container_name: make-recall-decision-api
     ports:
       - "8080:8080"
@@ -11,20 +13,8 @@ services:
     environment:
       - SERVER_PORT=8080
       - SPRING_PROFILES_ACTIVE=dev
-      - HMPPS_AUTH_URL=http://localhost:8080/auth
-
-  hmpps-auth:
-    image: quay.io/hmpps/hmpps-auth:latest
-    networks:
-      - hmpps
-    container_name: hmpps-auth
-    ports:
-      - "9090:8080"
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/auth/ping"]
-    environment:
-      - SPRING_PROFILES_ACTIVE=dev
-      - APPLICATION_AUTHENTICATION_UI_ALLOWLIST=0.0.0.0/0
+      - HMPPS_AUTH_URL=http://hmpps-auth:8080/auth # auth comes from UI docker-compose
 
 networks:
   hmpps:
+    name: hmpps

--- a/scripts/start-local-services.sh
+++ b/scripts/start-local-services.sh
@@ -17,14 +17,14 @@ pkill node || true
 pushd "${API_DIR}"
 printf "\n\nBuilding/starting API components...\n\n"
 docker compose pull
-docker compose up -d --scale=app=0
+docker compose up -d --scale=${API_NAME}=0
 SPRING_PROFILES_ACTIVE=dev ./gradlew bootRun >>"${API_LOGFILE}" 2>&1 &
 popd
 
 pushd "${UI_DIR}"
 printf "\n\nBuilding/starting UI components...\n\n"
 docker compose pull
-docker compose up -d --scale=app=0 --scale=hmpps-auth=0
+docker compose up -d --scale=${UI_NAME}=0
 npm install
 npm run start:dev >>"${UI_LOGFILE}" 2>&1 &
 popd


### PR DESCRIPTION
- ensure that the docker-compose containers run on the `hmpps` network -
  and that it's *just* called `hmpps`.
- remove auth as this can now be used from UI

This change allows the two docker-compose setups to share the same
network and namespace meaning we can reduce duplication across the two
apps environments.

ref MRD-28