### PR TITLE
MRD-11: Enable prometheus metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,5 +31,6 @@ COPY --from=builder --chown=appuser:appgroup /app/applicationinsights.json /app
 COPY --from=builder --chown=appuser:appgroup /app/applicationinsights.dev.json /app
 
 USER 2000
+EXPOSE 8080 8081
 
 ENTRYPOINT ["java", "-javaagent:/app/agent.jar", "-jar", "/app/app.jar"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,8 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-security")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+  implementation("org.springframework.boot:spring-boot-starter-actuator:2.6.5")
+  implementation("io.micrometer:micrometer-registry-prometheus:1.8.4")
 
   "5.7.3".let { sentryVersion ->
     implementation("io.sentry:sentry-spring-boot-starter:$sentryVersion")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,9 @@ services:
     container_name: make-recall-decision-api
     ports:
       - "8080:8080"
+      - "8081:8081"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health/ping"]
+      test: ["CMD", "curl", "-f", "http://localhost:8081/health/ping"]
     environment:
       - SERVER_PORT=8080
       - SPRING_PROFILES_ACTIVE=dev

--- a/helm_deploy/make-recall-decision-api/values.yaml
+++ b/helm_deploy/make-recall-decision-api/values.yaml
@@ -15,6 +15,15 @@ generic-service:
     tlsSecretName: make-recall-decision-cert
     contextColour: green
 
+  livenessProbe:
+    httpGet:
+      path: /health/liveness
+      port: metrics
+  readinessProbe:
+    httpGet:
+      path: /health/readiness
+      port: metrics
+
   # Environment variables to load into the deployment
   env:
     JAVA_OPTS: "-Xmx512m"
@@ -44,6 +53,12 @@ generic-service:
     cloudplatform-live-1: "35.178.209.113/32"
     cloudplatform-live-2: "3.8.51.207/32"
     cloudplatform-live-3: "35.177.252.54/32"
+
+  custommetrics:
+    enabled: true
+    scrapeInterval: 15s
+    metricsPath: /prometheus
+    metricsPort: 8081
 
 generic-prometheus-alerts:
   targetApplication: make-recall-decision-api

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/config/ResourceServerConfiguration.kt
@@ -19,7 +19,7 @@ class ResourceServerConfiguration : WebSecurityConfigurerAdapter() {
       .and().csrf().disable()
       .authorizeRequests { auth ->
         auth.antMatchers(
-          "/health/**", "/info",
+          "/health/**", "/info", "/prometheus",
           "/v3/api-docs/**",
           "/swagger-ui/**", "/swagger-ui.html",
           "/swagger-resources",

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,13 +53,17 @@ server:
     include-message: always
 
 management:
+  server:
+    port: 8081
   endpoints:
+    enabled-by-default: false
     web:
       base-path: /
       exposure:
-        include: 'info, health'
+        include: 'info, health, prometheus'
   endpoint:
     health:
+      enabled: true
       cache:
         time-to-live: 2000ms
       show-components: always
@@ -67,5 +71,8 @@ management:
       probes:
         enabled: true
     info:
+      enabled: true
       cache:
         time-to-live: 2000ms
+    prometheus:
+      enabled: true

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/health/HealthCheckTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/health/HealthCheckTest.kt
@@ -2,11 +2,13 @@ package uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.health
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.IntegrationTestBase
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.function.Consumer
 
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT, properties = ["management.server.port=9999", "server.port=9999"])
 class HealthCheckTest : IntegrationTestBase() {
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/health/InfoTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/health/InfoTest.kt
@@ -2,10 +2,12 @@ package uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.health
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.IntegrationTestBase
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT, properties = ["management.server.port=9998", "server.port=9998"])
 class InfoTest : IntegrationTestBase() {
 
   @Test


### PR DESCRIPTION
This moves all the springboot management functions onto port 8081,
enables prometheus metrics and also configures the k8s environment to
get them scraped.