### PR TITLE
(Re-)Add an external `/health` endpoint.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/controller/HealthController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/controller/HealthController.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.makerecalldecisionapi.controller
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
+class HealthController {
+  @GetMapping("/health")
+  @ResponseStatus(HttpStatus.OK)
+  fun getHealth(): Map<String, String> =
+    hashMapOf(
+      "status" to "UP",
+      "version" to version(),
+    )
+
+  private
+
+  fun version(): String = System.getenv("BUILD_NUMBER") ?: "app_version"
+}


### PR DESCRIPTION
Now that all the management functions have been moved to port 8081 and
made private to the k8s cluster we need something that doesn't need
authentication for external services to ping.

This will be used by `make-recall-decision-ui` (in it's healthchecks)
and pingdom when I set that up.