### PR TITLE
Hit the /health endpoint as the readiness check

### DIFF
--- a/helm_deploy/make-recall-decision-api/values.yaml
+++ b/helm_deploy/make-recall-decision-api/values.yaml
@@ -21,7 +21,7 @@ generic-service:
       port: metrics
   readinessProbe:
     httpGet:
-      path: /health/readiness
+      path: /health
       port: metrics
 
   # Environment variables to load into the deployment


### PR DESCRIPTION
This will ensure we get regular heartbeat data on our upstream dependencies