### PR TITLE
Don't log the OperationID on the /health endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/config/SentryConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/config/SentryConfig.kt
@@ -24,7 +24,9 @@ class SentryContextAppender : HandlerInterceptor {
   ): Boolean {
     val operationId: String = Span.current().spanContext.traceId
 
-    log.info("[preHandle] ${request.method} ${request.requestURI} - operationId: $operationId")
+    if (request.requestURI != "/health") {
+      log.info("[preHandle] ${request.method} ${request.requestURI} - operationId: $operationId")
+    }
 
     Sentry.configureScope { scope ->
       scope.setContexts("appInsightsOperationId", operationId)


### PR DESCRIPTION
This cuts down on a bit of log noise.

ref: https://mojdt.slack.com/archives/C03B57W0ALT/p1652696693028719?thread_ts=1652691808.694999&cid=C03B57W0ALT