### PR TITLE
Update the hmpps gradle-spring-boot plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.1.6"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.1.7"
   kotlin("plugin.spring") version "1.6.21"
 }
 


### PR DESCRIPTION
This resolves the netty (false positive) CVE warnings - ref https://mojdt.slack.com/archives/C69NWE339/p1652770667158019