### PR TITLE
NO_JIRA_spring-version-bump:

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.2.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.2.3"
   id("jacoco")
   id("org.sonarqube") version "3.3"
   kotlin("plugin.spring") version "1.6.21"


### PR DESCRIPTION
Fix for security scan on issues CVE-2022-22978 and CVE-2022-22976.