### PR TITLE
Switched H2 embedded test database for a Postgres Docker container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,16 +48,12 @@ slack-fail-post-step: &slack-fail-post-step
 
 jobs:
   validate:
-    executor:
-      name: hmpps/java_postgres
-      jdk_tag: "18.0"
-      postgres_tag: 13-alpine
-      postgres_username: mrd_user
-      postgres_password: secret
-      postgres_db: make_recall_decision
+    machine:
+      image: ubuntu-2204:2022.04.1
+      docker_layer_caching: true
+    resource_class: xlarge
     steps:
       - checkout
-      - hmpps/wait_till_ready_postgres
       - gradle/with_cache:
           cache_checksum_file: "build.gradle.kts"
           steps:
@@ -130,6 +126,7 @@ jobs:
       - store_test_results:
           path: make-recall-decision-ui/e2e_tests/junit
 
+
 workflows:
   version: 2
   build-test-and-deploy:
@@ -196,7 +193,7 @@ workflows:
             - hmpps-common-vars
             - make-recall-decision-api-preprod
           requires:
-           - deploy_dev
+            - deploy_dev
           <<: *slack-fail-post-step
       - hmpps/sentry_release_and_deploy:
           name: notify_sentry_preprod

--- a/README.md
+++ b/README.md
@@ -76,4 +76,3 @@ Run the following script to run all he tests locally (or to see how to run them)
 
 [make-recall-decision-api]: https://github.com/ministryofjustice/make-recall-decision-api
 [make-recall-decision-ui]: https://github.com/ministryofjustice/make-recall-decision-ui
-

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
 
   implementation("com.github.doyaaaaaken:kotlin-csv-jvm:1.3.0")
+  implementation("com.vladmihalcea:hibernate-types-52:2.16.3")
 
   testImplementation("org.mock-server:mockserver-netty:5.13.2")
   testImplementation("io.projectreactor:reactor-test")
@@ -55,7 +56,6 @@ dependencies {
   testImplementation("io.jsonwebtoken:jjwt:0.9.1")
   testImplementation("com.natpryce:hamkrest:1.8.0.1")
   testImplementation("org.flywaydb.flyway-test-extensions:flyway-spring-test:7.0.0")
-  testImplementation("com.h2database:h2:2.1.214")
 
   testImplementation("io.rest-assured:rest-assured:$restAssuredVersion")
   implementation("io.rest-assured:json-path:$restAssuredVersion")

--- a/docker-compose-integration-test-postgres.yml
+++ b/docker-compose-integration-test-postgres.yml
@@ -1,0 +1,26 @@
+version: '3.5'
+
+services:
+  postgres:
+    image: postgres
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-mrd_user}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-secret}
+      POSTGRES_DB: make_recall_decision
+      PGDATA: /data/postgres
+    volumes:
+      - "./src/main/resources/db/migration/V1_0__RECOMMENDATIONS_TABLE.sql:/docker-entrypoint-initdb.d/1.sql"
+      - "./src/main/resources/db/migration/V1_1__RECOMMENDATIONS_TABLE.sql:/docker-entrypoint-initdb.d/2.sql"
+      - "./src/main/resources/db/migration/V1_2__RECOMMENDATIONS_TABLE.sql:/docker-entrypoint-initdb.d/3.sql"
+    ports:
+      - "5432:5432"
+    networks:
+      - postgres
+    restart: unless-stopped
+
+networks:
+  postgres:
+    driver: bridge
+
+volumes:
+    postgres:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/config/MakeRecallDecisionApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/config/MakeRecallDecisionApiExceptionHandler.kt
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.exception.ClientTimeoutException
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.exception.DocumentNotFoundException
+import uk.gov.justice.digital.hmpps.makerecalldecisionapi.exception.NoRecommendationFoundException
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.exception.PersonNotFoundException
 import javax.validation.ValidationException
 
@@ -25,6 +26,20 @@ class MakeRecallDecisionApiExceptionHandler {
         ErrorResponse(
           status = BAD_REQUEST,
           userMessage = "Validation failure: ${e.message}",
+          developerMessage = e.message
+        )
+      )
+  }
+
+  @ExceptionHandler(NoRecommendationFoundException::class)
+  fun handleRecommendationFoundException(e: NoRecommendationFoundException): ResponseEntity<ErrorResponse> {
+    log.info("Recommendation not found exception: {}", e.message)
+    return ResponseEntity
+      .status(NOT_FOUND)
+      .body(
+        ErrorResponse(
+          status = NOT_FOUND,
+          userMessage = "No recommendation available: ${e.message}",
           developerMessage = e.message
         )
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/controller/RecommendationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/controller/RecommendationController.kt
@@ -15,9 +15,8 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.CreateRecommendationRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.CreateRecommendationResponse
-import uk.gov.justice.digital.hmpps.makerecalldecisionapi.jpa.entity.RecommendationEntity
+import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.RecommendationResponse
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.service.RecommendationService
-import java.util.Optional
 
 @RestController
 @RequestMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
@@ -42,7 +41,7 @@ internal class RecommendationController(
   @PreAuthorize("hasRole('ROLE_MAKE_RECALL_DECISION')")
   @GetMapping("/recommendations/{recommendationId}")
   @Operation(summary = "WIP: Gets a recommendation")
-  suspend fun getRecommendation(@PathVariable("recommendationId") recommendationId: Long): Optional<RecommendationEntity> {
+  suspend fun getRecommendation(@PathVariable("recommendationId") recommendationId: Long): RecommendationResponse {
     log.info(normalizeSpace("Get recommendation details endpoint hit for recommendation id: $recommendationId"))
     return recommendationService.getRecommendation(recommendationId)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/RecommendationResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/RecommendationResponse.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions
+
+data class RecommendationResponse(
+  val id: Long?,
+  val crn: String?
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/exception/NoRecommendationFoundException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/exception/NoRecommendationFoundException.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.makerecalldecisionapi.exception
+
+class NoRecommendationFoundException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/jpa/entity/EntityWithId.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/jpa/entity/EntityWithId.kt
@@ -1,13 +1,16 @@
 package uk.gov.justice.digital.hmpps.makerecalldecisionapi.jpa.entity
 
+import com.vladmihalcea.hibernate.type.json.JsonBinaryType
+import org.hibernate.annotations.TypeDef
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
 import javax.persistence.Id
 import javax.persistence.MappedSuperclass
 
 @MappedSuperclass
+@TypeDef(name = "jsonb", typeClass = JsonBinaryType::class)
 open class EntityWithId(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  var id: Long? = null,
+  open var id: Long? = null
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/jpa/entity/RecommendationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/jpa/entity/RecommendationEntity.kt
@@ -1,16 +1,25 @@
 package uk.gov.justice.digital.hmpps.makerecalldecisionapi.jpa.entity
 
+import org.hibernate.annotations.Type
+import java.io.Serializable
+import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.Table
 
 @Entity
 @Table(name = "recommendations")
 data class RecommendationEntity(
+  @Type(type = "jsonb")
+  @Column(columnDefinition = "jsonb")
+  var data: RecommendationModel
+) : EntityWithId()
+
+data class RecommendationModel(
   var name: String? = null,
   val crn: String?,
   var recommendation: Recommendation? = null,
   var alternateActions: String? = null
-) : EntityWithId()
+) : Serializable
 
 enum class Recommendation {
   RECALL, NOT_RECALL

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/RecommendationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/RecommendationService.kt
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.CreateRecommendationRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.CreateRecommendationResponse
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.RecommendationResponse
+import uk.gov.justice.digital.hmpps.makerecalldecisionapi.exception.NoRecommendationFoundException
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.jpa.entity.RecommendationEntity
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.jpa.entity.RecommendationModel
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.jpa.repository.RecommendationRepository
@@ -23,9 +24,10 @@ internal class RecommendationService(
   @OptIn(ExperimentalStdlibApi::class)
   fun getRecommendation(recommendationId: Long): RecommendationResponse {
     val recommendationEntity = recommendationRepository.findById(recommendationId).getOrNull()
+      ?: throw NoRecommendationFoundException("No recommendation found for id: $recommendationId")
     return RecommendationResponse(
-      id = recommendationEntity?.id,
-      crn = recommendationEntity?.data?.crn
+      id = recommendationEntity.id,
+      crn = recommendationEntity.data.crn
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/RecommendationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/RecommendationService.kt
@@ -3,22 +3,29 @@ package uk.gov.justice.digital.hmpps.makerecalldecisionapi.service
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.CreateRecommendationRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.CreateRecommendationResponse
+import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.RecommendationResponse
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.jpa.entity.RecommendationEntity
+import uk.gov.justice.digital.hmpps.makerecalldecisionapi.jpa.entity.RecommendationModel
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.jpa.repository.RecommendationRepository
-import java.util.Optional
+import kotlin.jvm.optionals.getOrNull
 
 @Service
 internal class RecommendationService(
   val recommendationRepository: RecommendationRepository
 ) {
   fun createRecommendation(recommendationRequest: CreateRecommendationRequest): CreateRecommendationResponse {
-    val savedRecommendation = recommendationRepository.save(RecommendationEntity(crn = recommendationRequest.crn))
+    val savedRecommendation = recommendationRepository.save(RecommendationEntity(data = RecommendationModel(crn = recommendationRequest.crn)))
     return CreateRecommendationResponse(
       id = savedRecommendation.id
     )
   }
 
-  fun getRecommendation(recommendationId: Long): Optional<RecommendationEntity> {
-    return recommendationRepository.findById(recommendationId)
+  @OptIn(ExperimentalStdlibApi::class)
+  fun getRecommendation(recommendationId: Long): RecommendationResponse {
+    val recommendationEntity = recommendationRepository.findById(recommendationId).getOrNull()
+    return RecommendationResponse(
+      id = recommendationEntity?.id,
+      crn = recommendationEntity?.data?.crn
+    )
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,10 @@ info.app:
     email: feedback@digital.justice.gov.uk
 
 spring:
+  jpa:
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQL95Dialect
   application:
     name: make-recall-decision-api
   codec:

--- a/src/main/resources/db/migration/V1_2__RECOMMENDATIONS_TABLE.sql
+++ b/src/main/resources/db/migration/V1_2__RECOMMENDATIONS_TABLE.sql
@@ -1,0 +1,7 @@
+drop table if exists recommendations;
+
+CREATE TABLE recommendations
+(
+    id serial primary key,
+    data jsonb
+);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/IntegrationTestBase.kt
@@ -82,7 +82,6 @@ abstract class IntegrationTestBase {
 
   @BeforeEach
   fun startUpServer() {
-    repository.deleteAll()
     communityApi.reset()
     offenderSearchApi.reset()
     gotenbergMock.reset()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/controller/RecommendationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/controller/RecommendationControllerTest.kt
@@ -1,9 +1,11 @@
 package uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.controller
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.web.reactive.function.BodyInserters
@@ -37,6 +39,22 @@ class RecommendationControllerTest() : IntegrationTestBase() {
       .expectBody()
       .jsonPath("$.id").isEqualTo(1)
       .jsonPath("$.crn").isEqualTo(crn)
+  }
+
+  @Test
+  fun `handles scenario where no recommendation exists for given id`() {
+    runTest {
+      webTestClient.get()
+        .uri("/recommendations/999")
+        .headers { it.authToken(roles = listOf("ROLE_MAKE_RECALL_DECISION")) }
+        .exchange()
+        .expectStatus()
+        .isNotFound
+        .expectBody()
+        .jsonPath("$.status").isEqualTo(HttpStatus.NOT_FOUND.value())
+        .jsonPath("$.userMessage")
+        .isEqualTo("No recommendation available: No recommendation found for id: 999")
+    }
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/health/HealthCheckTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/health/HealthCheckTest.kt
@@ -1,5 +1,8 @@
 package uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.health
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
@@ -15,10 +18,13 @@ import org.springframework.jdbc.datasource.DriverManagerDataSource
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.transaction.annotation.EnableTransactionManagement
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.controller.RecommendationControllerTest.Companion.setUpDb
+import uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.controller.RecommendationControllerTest.Companion.tearDownDb
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter.ISO_DATE
 import javax.sql.DataSource
 
+@ExperimentalCoroutinesApi
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT, properties = ["management.server.port=9999", "server.port=9999"])
 class HealthCheckTest : IntegrationTestBase() {
@@ -112,6 +118,20 @@ class HealthCheckTest : IntegrationTestBase() {
 
   private fun WebTestClient.BodyContentSpec.hasJsonPath(jsonPath: String, equalTo: String) =
     jsonPath(jsonPath).isEqualTo(equalTo)
+
+  companion object {
+    @JvmStatic
+    @BeforeAll
+    fun beforeAll() {
+      setUpDb()
+    }
+
+    @JvmStatic
+    @AfterAll
+    fun afterAll() {
+      tearDownDb()
+    }
+  }
 }
 
 @Configuration
@@ -120,8 +140,8 @@ class JpaConfig(private val env: Environment) {
   @Bean
   fun dataSource(): DataSource {
     val dataSource = DriverManagerDataSource()
-    dataSource.setDriverClassName("org.h2.Driver")
-    dataSource.url = "jdbc:h2:mem:myDb;DB_CLOSE_DELAY=-1"
+    dataSource.setDriverClassName("org.postgresql.Driver")
+    dataSource.url = "jdbc:postgresql://127.0.0.1:5432/make_recall_decision"
     dataSource.username = "mrd_user"
     dataSource.password = "secret"
     return dataSource

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/RecommendationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/RecommendationServiceTest.kt
@@ -1,8 +1,7 @@
 package uk.gov.justice.digital.hmpps.makerecalldecisionapi.service
 
-import com.natpryce.hamkrest.assertion.assertThat
-import com.natpryce.hamkrest.equalTo
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -13,6 +12,7 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.CreateRecommendationRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.jpa.entity.RecommendationEntity
+import uk.gov.justice.digital.hmpps.makerecalldecisionapi.jpa.entity.RecommendationModel
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.jpa.repository.RecommendationRepository
 import java.util.Optional
 
@@ -34,7 +34,7 @@ internal class RecommendationServiceTest : ServiceTestBase() {
   fun `saves a recommendation to the database`() {
     // given
     val crn = "12345"
-    val recommendationToSave = RecommendationEntity(crn = crn)
+    val recommendationToSave = RecommendationEntity(data = RecommendationModel(crn = crn))
 
     // and
     given(recommendationRepository.save(any()))
@@ -49,13 +49,14 @@ internal class RecommendationServiceTest : ServiceTestBase() {
 
   @Test
   fun `get a recommendation from the database`() {
-    val recommendation = Optional.of(RecommendationEntity(crn = "12345"))
+    val recommendation = Optional.of(RecommendationEntity(RecommendationModel(crn = "12345")))
 
     given(recommendationRepository.findById(456L))
       .willReturn(recommendation)
 
     val result = recommendationService.getRecommendation(456L)
 
-    assertThat(result, equalTo(recommendation))
+    assertThat(result.id).isEqualTo(recommendation.get().id)
+    assertThat(result.crn).isEqualTo(recommendation.get().data.crn)
   }
 }


### PR DESCRIPTION
H2 doesn't support json blobs, which is the reason for the switch here.
In this PR I've also changed the Circle CI build environment from the standard Docker Container to an Ubuntu VM.
Our tests need a VM in order to use the Docker Postgres container in CI.