### PR TITLE
MRD-383_add-functional-tests-to-ci:

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
       - checkout
       - run:
           name: Run Functional Tests tests on dev
-          command: ./scripts/run-functional-test.sh -e dev
+          command: ./gradlew functional-test-light
 
   e2e_test:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,24 @@ jobs:
       - store_artifacts:
           path: build/reports/jacoco/test/html
 
+  functional_test:
+    circleci_ip_ranges: true
+    executor:
+      name: hmpps/java_postgres
+      jdk_tag: "18.0"
+      postgres_tag: 13-alpine
+      postgres_username: mrd_user
+      postgres_password: secret
+      postgres_db: make_recall_decision
+    parameters:
+      environment:
+        type: string
+    steps:
+      - checkout
+      - run:
+          name: Run Functional Tests tests on dev
+          command: ./scripts/run-functional-test.sh -e dev
+
   e2e_test:
     executor:
       name: hmpps/default
@@ -154,6 +172,12 @@ workflows:
             - hmpps-common-vars
           <<: *slack-fail-post-step
 
+      - functional_test:
+          environment: dev
+          context:
+            - hmpps-common-vars
+          <<: *slack-fail-post-step
+
       - hmpps/build_docker:
           name: build_docker
           filters:
@@ -175,6 +199,7 @@ workflows:
                 - main
           requires:
             - validate
+            - functional_test
             - build_docker
             - e2e_local_test
             - helm_lint

--- a/README.md
+++ b/README.md
@@ -76,4 +76,3 @@ Run the following script to run all he tests locally (or to see how to run them)
 
 [make-recall-decision-api]: https://github.com/ministryofjustice/make-recall-decision-api
 [make-recall-decision-ui]: https://github.com/ministryofjustice/make-recall-decision-ui
-

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -7,6 +7,30 @@ generic-service:
   ingress:
     host: make-recall-decision-api-dev.hmpps.service.justice.gov.uk
 
+  allowlist:
+    # Circle CI allowed for functional tests. IP ranges defined here: https://circleci.com/docs/2.0/ip-ranges#list-of-ip-address-ranges
+    circle-ci-1: "3.228.39.90"
+    circle-ci-2: "18.213.67.41"
+    circle-ci-3: "34.194.94.201"
+    circle-ci-4: "34.194.144.202"
+    circle-ci-5: "34.197.6.234"
+    circle-ci-6: "35.169.17.173"
+    circle-ci-7: "35.174.253.146"
+    circle-ci-8: "52.3.128.216"
+    circle-ci-9: "52.4.195.249"
+    circle-ci-10: "52.5.58.121"
+    circle-ci-11: "52.21.153.129"
+    circle-ci-12: "52.72.72.233"
+    circle-ci-13: "54.92.235.88"
+    circle-ci-14: "54.161.182.76"
+    circle-ci-15: "54.164.161.41"
+    circle-ci-16: "54.166.105.113"
+    circle-ci-17: "54.167.72.230"
+    circle-ci-18: "54.172.26.132"
+    circle-ci-19: "54.205.138.102"
+    circle-ci-20: "54.208.72.234"
+    circle-ci-21: "54.209.115.53"
+
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     SENTRY_ENVIRONMENT: DEV

--- a/scripts/run-functional-test.sh
+++ b/scripts/run-functional-test.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
 # start postgres db
-docker-compose -f ./docker-compose-postgres.yml up -d
-./scripts/wait-for-it.sh 127.0.0.1:5432 --strict -t 600
+#docker-compose -f ./docker-compose-postgres.yml up -d
+#./scripts/wait-for-it.sh 127.0.0.1:5432 --strict -t 600
 
 # start api
-./scripts/start-local-development.sh &
-./scripts/wait-for-it.sh 127.0.0.1:8080 --strict -t 600
+#./scripts/start-local-development.sh &
+#./scripts/wait-for-it.sh 127.0.0.1:8080 --strict -t 600
 
 # start functional test in separate jvm
 ./gradlew functional-test-light
 
 # clean up
-./scripts/clean-up-docker.sh
+#./scripts/clean-up-docker.sh

--- a/scripts/start-local-development.sh
+++ b/scripts/start-local-development.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euo pipefail
+#set -euo pipefail
 
 ./gradlew --stop
 ./gradlew clean

--- a/src/functional-test/kotlin/ft/ContactHistoryTest.kt
+++ b/src/functional-test/kotlin/ft/ContactHistoryTest.kt
@@ -16,7 +16,7 @@ class ContactHistoryTest() : FunctionalTest() {
       .given()
       .pathParam("crn", testCrn)
       .header("Authorization", token)
-      .get("http://127.0.0.1:8080/cases/{crn}/contact-history")
+      .get(BASE_URL + "cases/{crn}/contact-history")
 
     // then
     assertThat(lastResponse.getStatusCode()).isEqualTo(expected)

--- a/src/functional-test/kotlin/ft/FunctionalTest.kt
+++ b/src/functional-test/kotlin/ft/FunctionalTest.kt
@@ -5,16 +5,20 @@ import io.restassured.response.Response
 import org.assertj.core.api.Assertions.assertThat
 import org.json.JSONObject
 import org.junit.jupiter.api.BeforeAll
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import java.util.Base64
+import kotlin.math.log
 
 open class FunctionalTest {
-  val BASE_URL = "https://make-recall-decision-api-dev.hmpps.service.justice.gov.uk/"
   lateinit var lastResponse: Response
   val token = "Bearer ${getToken()}"
   val testCrn = "D006296"
   companion object {
+    val BASE_URL = "https://make-recall-decision-api-dev.hmpps.service.justice.gov.uk/"
+    private val log: Logger = LoggerFactory.getLogger(this::class.java)
     val client_id = System.getenv("SYSTEM_CLIENT_ID")
     val client_secret = System.getenv("SYSTEM_CLIENT_SECRET")
     val base64EncodedClientCreds = Base64.getEncoder().encodeToString("$client_id:$client_secret".toByteArray())
@@ -23,11 +27,13 @@ open class FunctionalTest {
 
     @BeforeAll
     private fun getToken(): String {
+      log.info("Running Functional Tests against $BASE_URL")
       val tokenResponse = RestAssured
         .given()
         .contentType(APPLICATION_JSON_VALUE)
         .header("Authorization", authHeaderValue)
         .post(authPath)
+      log.info("Response from Auth on getting token:: ${tokenResponse.statusCode}")
       assertThat(tokenResponse.statusCode).isEqualTo(HttpStatus.OK.value())
       return JSONObject(tokenResponse.body().asString()).getString("access_token")
     }

--- a/src/functional-test/kotlin/ft/FunctionalTest.kt
+++ b/src/functional-test/kotlin/ft/FunctionalTest.kt
@@ -10,6 +10,7 @@ import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import java.util.Base64
 
 open class FunctionalTest {
+  val BASE_URL = "https://make-recall-decision-api-dev.hmpps.service.justice.gov.uk/"
   lateinit var lastResponse: Response
   val token = "Bearer ${getToken()}"
   val testCrn = "D006296"

--- a/src/functional-test/kotlin/ft/LicenceConditionsTest.kt
+++ b/src/functional-test/kotlin/ft/LicenceConditionsTest.kt
@@ -16,7 +16,7 @@ class LicenceConditionsTest() : FunctionalTest() {
       .given()
       .pathParam("crn", testCrn)
       .header("Authorization", token)
-      .get("http://127.0.0.1:8080/cases/{crn}/licence-conditions")
+      .get(BASE_URL + "cases/{crn}/licence-conditions")
 
     // then
     assertThat(lastResponse.getStatusCode()).isEqualTo(expected)

--- a/src/functional-test/kotlin/ft/OffenderSearchTest.kt
+++ b/src/functional-test/kotlin/ft/OffenderSearchTest.kt
@@ -16,7 +16,7 @@ class OffenderSearchTest() : FunctionalTest() {
       .given()
       .queryParam("crn", testCrn)
       .header("Authorization", token)
-      .get("http://127.0.0.1:8080/search")
+      .get(BASE_URL+ "search")
 
     // then
     assertThat(lastResponse.getStatusCode()).isEqualTo(expected)

--- a/src/functional-test/kotlin/ft/OverviewTest.kt
+++ b/src/functional-test/kotlin/ft/OverviewTest.kt
@@ -16,7 +16,7 @@ class OverviewTest() : FunctionalTest() {
       .given()
       .pathParam("crn", testCrn)
       .header("Authorization", token)
-      .get("http://127.0.0.1:8080/cases/{crn}/overview")
+      .get(BASE_URL + "cases/{crn}/overview")
 
     // then
     assertThat(lastResponse.getStatusCode()).isEqualTo(expected)

--- a/src/functional-test/kotlin/ft/PersonalDetailsTest.kt
+++ b/src/functional-test/kotlin/ft/PersonalDetailsTest.kt
@@ -16,7 +16,7 @@ class PersonalDetailsTest() : FunctionalTest() {
       .given()
       .pathParam("crn", testCrn)
       .header("Authorization", token)
-      .get("http://127.0.0.1:8080/cases/{crn}/personal-details")
+      .get(BASE_URL + "cases/{crn}/personal-details")
 
     // then
     assertThat(lastResponse.getStatusCode()).isEqualTo(expected)

--- a/src/functional-test/kotlin/ft/RecommendationTest.kt
+++ b/src/functional-test/kotlin/ft/RecommendationTest.kt
@@ -18,7 +18,7 @@ class RecommendationTest() : FunctionalTest() {
       .contentType(APPLICATION_JSON_VALUE)
       .header("Authorization", token)
       .body(recommendationRequest("X12345"))
-      .post("http://127.0.0.1:8080/recommendations")
+      .post(BASE_URL + "recommendations")
 
     // then
     assertThat(lastResponse.getStatusCode()).isEqualTo(expected)

--- a/src/functional-test/kotlin/ft/RiskTest.kt
+++ b/src/functional-test/kotlin/ft/RiskTest.kt
@@ -18,7 +18,7 @@ class RiskTest() : FunctionalTest() {
       .given()
       .pathParam("crn", testCrn)
       .header("Authorization", token)
-      .get("http://127.0.0.1:8080/cases/{crn}/risk")
+      .get(BASE_URL + "cases/{crn}/risk")
 
     // then
     assertThat(lastResponse.getStatusCode()).isEqualTo(expected)


### PR DESCRIPTION
1) added functional-test step to the circle-ci pipeline to run on dev only
2) allowlisted circle-ci ips to let MOJ services talk to CircleCI VM where test is run
3) enabled circleci_ip_ranges in circle-ci config to permit a range of ips to be allowlisted.