### PR TITLE
Reuse ARN renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
   "extends": [
-    "config:base"
+     ["github>ministryofjustice/arn-renovate-config"]
   ]
 }


### PR DESCRIPTION
Quite a lot of other services are reusing the ARN renovate config. This seems to group all minor updates into one PR so should make the Renovate PRs a lot less noisy. 