### PR TITLE
MRD-559 - Part A mapper - If a boolean is not set, return empty string

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/util/RecommendationToPartADataMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/util/RecommendationToPartADataMapper.kt
@@ -65,7 +65,7 @@ class RecommendationToPartADataMapper {
     }
 
     private fun convertBooleanToYesNo(value: Boolean?): String {
-      return if (value == true) YES else NO
+      if (value == true) return YES else if (value == false) return NO else return EMPTY_STRING
     }
 
     private fun buildAlternativeConditionsBreachedText(additionalLicenceConditions: AdditionalLicenceConditions?): String {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/util/RecommendationToPartADataMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/util/RecommendationToPartADataMapperTest.kt
@@ -140,6 +140,20 @@ class RecommendationToPartADataMapperTest {
   }
 
   @Test
+  fun `given has no arrest issues data then should map in part A text`() {
+    runTest {
+      val recommendation = RecommendationEntity(
+        id = 1,
+        data = RecommendationModel(crn = "ABC123", hasArrestIssues = SelectedWithDetails(selected = null))
+      )
+
+      val result = RecommendationToPartADataMapper.mapRecommendationDataToPartAData(recommendation)
+
+      assertThat(result.hasArrestIssues?.value).isEqualTo("")
+    }
+  }
+
+  @Test
   fun `given has contraband risk data then should map in part A text`() {
     runTest {
       val recommendation = RecommendationEntity(


### PR DESCRIPTION
eg generate a Part A without answering the 'arrest issues' or 'contraband' questions. The answers should be blank but are 'No'. This PR adjusts the `convertBooleanToYesNo` logic so if the property isn't set, an empty string is returned.