### PR TITLE
mrd-700_show-offence-description-when-no-match

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/CaseSummaryOverviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/CaseSummaryOverviewService.kt
@@ -30,7 +30,7 @@ internal class CaseSummaryOverviewService(
       val recommendationDetails = recommendationService.getDraftRecommendationForCrn(crn)
 
       val riskManagementPlan = riskService.getLatestRiskManagementPlan(crn)
-      val assessmentInfo = riskService.fetchAssessmentInfo(crn = crn, hideOffenceDetailsWhenLaterCompleteAssessmentAvailable = false)
+      val assessmentInfo = riskService.fetchAssessmentInfo(crn = crn, hideOffenceDetailsWhenNoMatch = false)
 
       val releaseSummary = getReleaseSummary(crn)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/RecommendationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/RecommendationService.kt
@@ -52,7 +52,7 @@ internal class RecommendationService(
       throw UserAccessException(Gson().toJson(userAccessResponse))
     } else {
       val personDetails = recommendationRequest.crn?.let { personDetailsService.getPersonDetails(it) }
-      val indexOffenceDetails = recommendationRequest.crn?.let { riskService?.fetchAssessmentInfo(crn = it, hideOffenceDetailsWhenLaterCompleteAssessmentAvailable = true) }
+      val indexOffenceDetails = recommendationRequest.crn?.let { riskService?.fetchAssessmentInfo(crn = it, hideOffenceDetailsWhenNoMatch = true) }
       val convictionResponse = (recommendationRequest.crn?.let { convictionService.buildConvictionResponse(it, false) })
       val convictionForRecommendation =
         buildRecommendationConvictionResponse(convictionResponse?.filter { it.isCustodial == true })
@@ -264,7 +264,7 @@ internal class RecommendationService(
     val crn = recommendationEntity.data.crn
     val riskResponse = crn?.let { riskService?.getRisk(it) }
     val personDetails = crn?.let { personDetailsService.getPersonDetails(it) }
-    val indexOffenceDetails = crn?.let { riskService?.fetchAssessmentInfo(crn = it, hideOffenceDetailsWhenLaterCompleteAssessmentAvailable = true) }
+    val indexOffenceDetails = crn?.let { riskService?.fetchAssessmentInfo(crn = it, hideOffenceDetailsWhenNoMatch = true) }
     val data = recommendationEntity.data
     val personOnProbation = data.personOnProbation
     return recommendationEntity.copy(


### PR DESCRIPTION
Updated matching rules of assessment info to allow offence details to be shown on overview screen where the offence codes do not match across OaSys and Delius.