### PR TITLE
no_jira_spring-boot-ver-bump: removed ApplicationInsights logging as …

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -6,44 +6,38 @@
 
     <springProperty scope="context" name="app" source="spring.application.name"/>
 
-
-    <springProfile name="dev || stdout">
-        <appender name="consoleAppender" class="ch.qos.logback.core.helpers.NOPAppender"/>
-        <appender name="logAppender" class="ch.qos.logback.core.ConsoleAppender">
-            <layout class="ch.qos.logback.classic.PatternLayout">
-                <Pattern>${LOG_PATTERN}</Pattern>
-            </layout>
-        </appender>
-    </springProfile>
+    <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>${LOG_PATTERN}</Pattern>
+        </layout>
+    </appender>
 
     <logger name="uk.gov.justice.digital.hmpps.makerecalldecisionapi.MakeRecallDecisionApiKt" additivity="false"
             level="DEBUG">
-        <appender-ref ref="logAppender"/>
         <appender-ref ref="consoleAppender"/>
     </logger>
 
     <logger name="uk.gov.justice.digital.hmpps" additivity="false" level="DEBUG">
-        <appender-ref ref="logAppender"/>
         <appender-ref ref="consoleAppender"/>
     </logger>
 
     <logger name="org.springframework" additivity="false" level="INFO">
-        <appender-ref ref="logAppender"/>
+        <appender-ref ref="consoleAppender"/>
+    </logger>
+
+    <logger name="com.microsoft.applicationinsights" additivity="false" level="INFO">
         <appender-ref ref="consoleAppender"/>
     </logger>
 
     <logger name="org.apache.catalina" additivity="false" level="INFO">
-        <appender-ref ref="logAppender"/>
         <appender-ref ref="consoleAppender"/>
     </logger>
 
     <logger name="org.springframework.boot" additivity="false" level="INFO">
-        <appender-ref ref="logAppender"/>
         <appender-ref ref="consoleAppender"/>
     </logger>
 
     <root level="INFO">
-        <appender-ref ref="logAppender"/>
         <appender-ref ref="consoleAppender"/>
     </root>
 


### PR DESCRIPTION
removed ApplicationInsights logging as no longer supported in SpringBoot V3