### PR TITLE
PI-577 Set licence conditions to active

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/LicenceConditionsResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/LicenceConditionsResponse.kt
@@ -29,6 +29,7 @@ data class LicenceConditionsResponse(
       statusCode = it.sentence?.custodialStatusCode,
       licenceConditions = it.licenceConditions.map { licenceCondition ->
         LicenceCondition(
+          active = true,
           licenceConditionNotes = licenceCondition.notes,
           licenceConditionTypeMainCat = LicenceConditionTypeMainCat(licenceCondition.mainCategory.code, licenceCondition.mainCategory.description),
           licenceConditionTypeSubCat = licenceCondition.subCategory?.let { subCategory -> LicenceConditionTypeSubCat(subCategory.code, subCategory.description) },


### PR DESCRIPTION
This fixes a bug in the backward-compatibility in the previous PR, that was picked up in our end-to-end tests. Note: the backward-compatibility code will be removed in another PR as soon as the UI has been updated to use the new fields, so this won't be around long.