### PR TITLE
PI-577 Remove staff code from management-oversight message

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/client/DeliusClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/client/DeliusClient.kt
@@ -57,8 +57,6 @@ class DeliusClient(
     )
   )
 
-  fun getStaff(username: String): Staff = getBody("/user/$username/staff")
-
   fun getUserAccess(username: String, crn: String): UserAccess = getBody("/user/$username/access/$crn")
 
   fun getDocument(crn: String, id: String): ResponseEntity<Resource> = get("/document/$crn/$id")
@@ -288,9 +286,6 @@ class DeliusClient(
   }
   data class ContactTypeSummary(val code: String, val description: String, val total: Int)
 
-  data class Staff(
-    val code: String?
-  )
   data class UserAccess(
     val exclusionMessage: String? = null,
     val restrictionMessage: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/config/MakeRecallDecisionApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/config/MakeRecallDecisionApiExceptionHandler.kt
@@ -14,7 +14,6 @@ import uk.gov.justice.digital.hmpps.makerecalldecisionapi.exception.ClientTimeou
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.exception.DocumentNotFoundException
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.exception.InvalidRequestException
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.exception.NoRecommendationFoundException
-import uk.gov.justice.digital.hmpps.makerecalldecisionapi.exception.NoStaffCodeException
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.exception.PersonNotFoundException
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.exception.RecommendationStatusUpdateException
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.exception.RecommendationUpdateException
@@ -123,21 +122,6 @@ class MakeRecallDecisionApiExceptionHandler {
           status = INTERNAL_SERVER_ERROR,
           userMessage = "Unexpected error: ${e.message}",
           developerMessage = e.message
-        )
-      )
-  }
-
-  @ExceptionHandler(NoStaffCodeException::class)
-  fun handleNoStaffCodeException(e: NoStaffCodeException): ResponseEntity<ErrorResponse?>? {
-    log.error("No staff code found  exception", e)
-    return ResponseEntity
-      .status(INTERNAL_SERVER_ERROR)
-      .body(
-        ErrorResponse(
-          status = INTERNAL_SERVER_ERROR,
-          userMessage = "Unexpected error: ${e.message}",
-          developerMessage = e.message,
-          error = e.error
         )
       )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/MrdEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/MrdEvent.kt
@@ -44,7 +44,7 @@ fun toDntrDownloadedEventPayload(crn: String?): MrdEvent {
   )
 }
 
-fun toManagerRecallDecisionMadeEventPayload(recommendationUrl: String?, crn: String?, contactOutcome: String?, username: String, staffCode: String?): MrdEvent {
+fun toManagerRecallDecisionMadeEventPayload(recommendationUrl: String?, crn: String?, contactOutcome: String?, username: String): MrdEvent {
   return MrdEvent(
     timeStamp = utcNowDateTimeString(),
     message = MrdEventMessageBody(
@@ -57,7 +57,7 @@ fun toManagerRecallDecisionMadeEventPayload(recommendationUrl: String?, crn: Str
       additionalInformation = AdditionalInformation(
         contactOutcome = contactOutcome,
         recommendationUrl = recommendationUrl,
-        bookedBy = BookedBy(username, staffCode)
+        bookedBy = BookedBy(username)
       )
     ),
     messageAttributes = MessageAttributes(eventType = TypeValue(type = "String", value = "prison-recall.recommendation.management-oversight"))
@@ -106,8 +106,7 @@ data class AdditionalInformation(
 )
 
 data class BookedBy(
-  val username: String,
-  val staffCode: String? = null
+  val username: String
 )
 
 data class TypeValue(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/exception/NoStaffCodeException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/exception/NoStaffCodeException.kt
@@ -1,3 +1,0 @@
-package uk.gov.justice.digital.hmpps.makerecalldecisionapi.exception
-
-class NoStaffCodeException(message: String, val error: String) : RuntimeException(message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/RecommendationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/RecommendationService.kt
@@ -254,8 +254,7 @@ internal class RecommendationService(
           sendManagerRecallDecisionMadeEvent(
             crn = existingRecommendationEntity.data.crn,
             contactOutcome = toDeliusContactOutcome(existingRecommendationEntity.data.managerRecallDecision?.selected?.value).toString(),
-            username = userId,
-            staffcode = deliusClient.getStaff(userId).code
+            username = userId
           )
         } catch (ex: Exception) {
           log.info("Failed to send domain event for ${updatedRecommendation.crn} on manager recall decision for recommendationId $recommendationId reverting isSentToDelius to false")
@@ -524,14 +523,13 @@ internal class RecommendationService(
     mrdEventsEmitter?.sendEvent(mrdEvent)
   }
 
-  private fun sendManagerRecallDecisionMadeEvent(crn: String?, contactOutcome: String?, username: String, staffcode: String?) {
+  private fun sendManagerRecallDecisionMadeEvent(crn: String?, contactOutcome: String?, username: String) {
     sendMrdEventToEventsEmitter(
       toManagerRecallDecisionMadeEventPayload(
         crn = crn,
         recommendationUrl = "$mrdUrl/cases/$crn/overview",
         contactOutcome = contactOutcome,
-        username = username,
-        staffCode = staffcode
+        username = username
       )
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/RecommendationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/RecommendationServiceTest.kt
@@ -33,7 +33,6 @@ import org.mockito.kotlin.firstValue
 import org.mockito.kotlin.willReturn
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.MrdTestDataBuilder
-import uk.gov.justice.digital.hmpps.makerecalldecisionapi.client.DeliusClient.Staff
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.client.DeliusClient.UserAccess
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.featureflags.FeatureFlags
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.Address
@@ -572,11 +571,6 @@ internal class RecommendationServiceTest : ServiceTestBase() {
         )
 
       // and
-      if (isSentToDelius == "true") {
-        given(deliusClient.getStaff(anyString())).willReturn(Staff(code = "ABC123"))
-      }
-
-      // and
       given(recommendationRepository.save(any()))
         .willReturn(recommendationToSave)
 
@@ -602,7 +596,6 @@ internal class RecommendationServiceTest : ServiceTestBase() {
         val mrdEvent = captor.firstValue
         assertThat(mrdEvent.message?.personReference?.identifiers?.get(0)?.value).isEqualTo(crn)
         assertThat(mrdEvent.message?.additionalInformation?.contactOutcome).isEqualTo("DECISION_TO_RECALL")
-        assertThat(mrdEvent.message?.additionalInformation?.bookedBy?.staffCode).isEqualTo("ABC123")
         assertThat(mrdEvent.message?.additionalInformation?.recommendationUrl).isNotNull
         assertThat(mrdEvent.type).isEqualTo("Notification")
         assertThat(mrdEvent.messageId).isNotNull


### PR DESCRIPTION
The probation integration consumer now accepts the "username" instead, which means you no longer need to call an extra endpoint to get the user's staff code.