### PR TITLE
PI-1025 Shutdown dev and preprod outside of business hours

### DIFF
--- a/helm_deploy/make-recall-decision-api/Chart.yaml
+++ b/helm_deploy/make-recall-decision-api/Chart.yaml
@@ -8,8 +8,8 @@ dependencies:
     version: 0.1.0
     repository: file://subcharts/gotenberg
   - name: generic-service
-    version: 2.5.0
+    version: 2.6.3
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.2.4
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -18,7 +18,11 @@ generic-service:
     MRD_URL: https://make-recall-decision-dev.hmpps.service.justice.gov.uk
     MRD_API_URL: https://make-recall-decision-api-dev.hmpps.service.justice.gov.uk
 
+  scheduledDowntime:
+    enabled: true
+
 generic-prometheus-alerts:
+  businessHoursOnly: true
   alertSeverity: make-recall-decision-nonprod
 
 gotenberg:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -16,7 +16,11 @@ generic-service:
     MRD_URL: https://make-recall-decision-preprod.hmpps.service.justice.gov.uk
     MRD_API_URL: https://make-recall-decision-api-preprod.hmpps.service.justice.gov.uk
 
+  scheduledDowntime:
+    enabled: true
+
 generic-prometheus-alerts:
+  businessHoursOnly: true
   alertSeverity: make-recall-decision-nonprod
 
 gotenberg:


### PR DESCRIPTION
This change shuts down the MRD API in dev and preprod between 10pm-6am on weekdays to save costs.  See https://github.com/ministryofjustice/hmpps-helm-charts/tree/main/charts/generic-service#scheduled-downtime