### PR TITLE
no_jira-fix-for-create-recommendation-with-trigger

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/RecommendationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/RecommendationService.kt
@@ -105,7 +105,7 @@ internal class RecommendationService(
       }
 
       val existingRecommendation = findInProgressRecommendationEntityForCase(recommendationRequest.crn)
-      return if (existingRecommendation != null) {
+      return if (existingRecommendation != null && featureFlags?.flagTriggerWork != true) {
         existingRecommendation.toRecommendationResponse()
       } else {
         val personDetails = recommendationRequest.crn?.let { personDetailsService.getPersonDetails(it) }


### PR DESCRIPTION
allow new recommendation to be created when active recommendation already present with trigger flag set