### PR TITLE
MRD-1712 Upgrade pipeline executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ slack-fail-post-step: &slack-fail-post-step
 jobs:
   validate:
     machine:
-      image: ubuntu-2204:2022.04.1
+      image: ubuntu-2204:2023.07.2
       docker_layer_caching: true
     resource_class: xlarge
     steps:
@@ -88,7 +88,7 @@ jobs:
 
   e2e_local_test:
     machine:
-      image: ubuntu-2004:2022.10.1
+      image: ubuntu-2004:2023.07.1
     parallelism: << pipeline.parameters.e2e-parallelism >>
     steps:
       - run:


### PR DESCRIPTION
This is mainly to match the UI for E2E so that Node 18 is used.