### PR TITLE
MRD-1788: Update the pipeline to run the E2E test from the new e2e_test repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,9 +148,6 @@ jobs:
           path: make-recall-decision-e2e-tests/e2e_tests/screenshots
           destination: screenshots
       - store_artifacts:
-          path: make-recall-decision-e2e-tests/e2e_tests/videos
-          destination: videos
-      - store_artifacts:
           path: make-recall-decision-e2e-tests/e2e_tests/logs
           destination: test-logs
       - store_artifacts:
@@ -159,8 +156,6 @@ jobs:
       - store_artifacts:
           path: make-recall-decision-e2e-tests/e2e_tests/junit
           destination: junit
-      - store_test_results:
-          path: make-recall-decision-e2e-tests/e2e_tests/junit
 
 # E2E tests using the dev and pre-prod environments have been commented out.
 # They were actingas a 'gate' to prevent a broken production deployment, this has been superceded by a 'manual' gate step.


### PR DESCRIPTION
- e2e_local_test job runs the test that are in the new make-recall-decision-e2e-tests repo 
- e2e_dev_test and e2e_preprod_test  job runs the test that are in the new make-recall-decision-e2e-tests repo 