### PR TITLE
Set application insights sampling to 100%

### DIFF
--- a/applicationinsights.dev.json
+++ b/applicationinsights.dev.json
@@ -13,6 +13,9 @@
   "selfDiagnostics": {
     "destination": "console"
   },
+  "sampling": {
+    "percentage": 100
+  },
   "preview": {
     "sampling": {
       "overrides": [

--- a/applicationinsights.json
+++ b/applicationinsights.json
@@ -13,6 +13,9 @@
   "selfDiagnostics": {
     "destination": "console"
   },
+  "sampling": {
+    "percentage": 100
+  },
   "preview": {
     "sampling": {
       "overrides": [

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/LicenceConditionsCoordinator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/LicenceConditionsCoordinator.kt
@@ -19,21 +19,23 @@ class LicenceConditionsCoordinator {
       isCvlLicenceMoreOrAsRecent(nDeliusLicenceConditions, cvlLicenceConditions, hasAllConvictionsReleasedOnLicence)
     return SelectedLicenceConditions(
       hasAllConvictionsReleasedOnLicence = hasAllConvictionsReleasedOnLicence,
-      ndeliusLicenceConditions = nDeliusLicenceConditions,
+      ndeliusActiveConvictions = nDeliusLicenceConditions.activeConvictions.filter { it.sentence?.isCustodial == true },
       cvlLicenceCondition = if (onLicenceCvlWithLaterOrSameStartDate) cvlLicenceConditions.firstOrNull() else null,
     )
   }
 
   private fun hasAllConvictionsReleasedOnLicence(nDeliusLicenceConditions: LicenceConditions): Boolean {
-    log.info("LC Issue Logging::" + " number of active custodial convictions::" + nDeliusLicenceConditions.activeConvictions.size)
+    log.info("LC Issue Logging::" + " number of active convictions::" + nDeliusLicenceConditions.activeConvictions.size)
     nDeliusLicenceConditions.activeConvictions.forEach {
       log.info("LC Issue Logging::" + " active conviction number::" + nDeliusLicenceConditions.activeConvictions.indexOf(it))
       log.info("LC Issue Logging::" + " custodialStatusCode::" + it.sentence?.custodialStatusCode)
       log.info("LC Issue Logging::" + " isCustodial::" + it.sentence?.isCustodial)
     }
-    val hasAllConvictionsReleasedOnLicence = nDeliusLicenceConditions.activeConvictions.isNotEmpty() && nDeliusLicenceConditions.activeConvictions.all {
-      it.sentence?.isCustodial == true && it.sentence.custodialStatusCode == "B"
-    }
+    val hasAllConvictionsReleasedOnLicence = nDeliusLicenceConditions.activeConvictions.isNotEmpty() &&
+      nDeliusLicenceConditions.activeConvictions.any { it.sentence?.isCustodial == true } &&
+      nDeliusLicenceConditions.activeConvictions
+        .filter { it.sentence?.isCustodial == true }
+        .all { it.sentence?.custodialStatusCode == "B" }
     log.info("LC Issue Logging::" + " hasAllConvictionsReleasedOnLicence::" + hasAllConvictionsReleasedOnLicence)
     return hasAllConvictionsReleasedOnLicence
   }
@@ -57,6 +59,6 @@ class LicenceConditionsCoordinator {
 
 data class SelectedLicenceConditions(
   val hasAllConvictionsReleasedOnLicence: Boolean,
-  val ndeliusLicenceConditions: LicenceConditions,
+  val ndeliusActiveConvictions: List<LicenceConditions.ConvictionWithLicenceConditions> = emptyList(),
   val cvlLicenceCondition: LicenceConditionResponse? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/LicenceConditionsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/LicenceConditionsService.kt
@@ -64,7 +64,7 @@ internal class LicenceConditionsService(
       LicenceConditionsResponse(
         hasAllConvictionsReleasedOnLicence = selectedLicenceConditions.hasAllConvictionsReleasedOnLicence,
         personalDetailsOverview = deliusLicenceConditions.personalDetails.toOverview(crn),
-        activeConvictions = deliusLicenceConditions.activeConvictions,
+        activeConvictions = selectedLicenceConditions.ndeliusActiveConvictions,
         activeRecommendation = recommendationDetails,
         cvlLicence = selectedLicenceConditions.cvlLicenceCondition,
       )


### PR DESCRIPTION
The app insights Java agent from 3.4.0 defaults to rate limited sampling.
This change simply matches the change in the HMPPS Kotlin template.