### PR TITLE
Set application insights sampling to 100%

### DIFF
--- a/applicationinsights.dev.json
+++ b/applicationinsights.dev.json
@@ -13,6 +13,9 @@
   "selfDiagnostics": {
     "destination": "console"
   },
+  "sampling": {
+    "percentage": 100
+  },
   "preview": {
     "sampling": {
       "overrides": [

--- a/applicationinsights.json
+++ b/applicationinsights.json
@@ -13,6 +13,9 @@
   "selfDiagnostics": {
     "destination": "console"
   },
+  "sampling": {
+    "percentage": 100
+  },
   "preview": {
     "sampling": {
       "overrides": [


### PR DESCRIPTION
The app insights Java agent from 3.4.0 defaults to rate limited sampling. 
This change matches the change in the HMPPS Kotlin template