### PR TITLE
Remove patch version from helm chart versions

### DIFF
--- a/helm_deploy/make-recall-decision-api/Chart.yaml
+++ b/helm_deploy/make-recall-decision-api/Chart.yaml
@@ -8,8 +8,8 @@ dependencies:
     version: 0.1.0
     repository: file://subcharts/gotenberg
   - name: generic-service
-    version: 2.7.2
+    version: 2.7
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.3
+    version: 1.3
     repository: https://ministryofjustice.github.io/hmpps-helm-charts


### PR DESCRIPTION
This means the latest patch version will be used, reducing the burden on keeping this up to date.