### PR TITLE
Configure Renovate to ignore logback

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,8 +85,8 @@ dependencies {
   implementation("org.apache.tomcat.embed:tomcat-embed-websocket:9.0.85")
   implementation("org.apache.tomcat:tomcat-annotations-api:9.0.85")
 
-  implementation("ch.qos.logback:logback-core:1.2.13") // Address CVE-2023-6378
-  implementation("ch.qos.logback:logback-classic:1.2.13") // Address CVE-2023-6378
+  implementation("ch.qos.logback:logback-core:1.2.13") // Address CVE-2023-6378. Renovate config ignores upgrades
+  implementation("ch.qos.logback:logback-classic:1.2.13") // Address CVE-2023-6378. Renovate config ignores upgrades
 }
 
 java {

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,9 @@
 {
-  "extends": ["github>ministryofjustice/arn-renovate-config"]
+  "extends": ["github>ministryofjustice/arn-renovate-config"],
+  "minor": {
+    "ignoreDeps": [
+      "logback-core",
+      "logback-classic"
+    ]
+  }
 }


### PR DESCRIPTION
Explicit logback versions 1.2.13 are requested in order to resolve a vulnerability. These cannot be upgraded beyond 1.2 until other dependencies that rely on them are upgraded.