### PR TITLE
Configure Renovate to ignore logback attempt 2

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,9 @@
 {
-  "extends": ["github>ministryofjustice/arn-renovate-config"],
-  "minor": {
-    "ignoreDeps": [
-      "logback-core",
-      "logback-classic"
-    ]
-  }
+  "extends": [
+    "github>ministryofjustice/arn-renovate-config"
+  ],
+  "ignoreDeps": [
+    "logback-core",
+    "logback-classic"
+  ]
 }


### PR DESCRIPTION
Explicit logback versions 1.2.13 are requested in order to resolve a vulnerability. These cannot be upgraded beyond 1.2 until other dependencies that rely on them are upgraded.