### PR TITLE
Reduce CVL timeout to 20s

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -142,7 +142,7 @@ arn:
 
 cvl:
   client:
-    timeout: 30
+    timeout: 20
   api:
     endpoint:
       url: http://localhost:9070


### PR DESCRIPTION
This should mean that we get the chance to retry when hit by the "ingress issue" but won't miss any successful calls.