### PR TITLE
Increase timeout for PPUD Automation

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -165,7 +165,7 @@ oasys:
 
 ppud-automation:
   client:
-    timeout: 60
+    timeout: 90
   api:
     endpoint:
       url: http://localhost:9370


### PR DESCRIPTION
Performance tests suggest that 60s is only the 78th percentile