### PR TITLE
Change default date time for nulls

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/util/MrdTextConstants.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/util/MrdTextConstants.kt
@@ -12,6 +12,12 @@ class MrdTextConstants {
     const val SCORE_NOT_APPLICABLE = "NOT_APPLICABLE"
     const val TICK_CHARACTER = 0x2713.toChar().toString()
     const val NO_NAME_AVAILABLE = "No name available"
-    const val DEFAULT_DATE_TIME_FOR_NULL_VALUE = "1970-01-01T00:00:00.000"
+
+    // We use a very early date to avoid incorrect orderings of entities with null date times.
+    // We deliberately don't use LocalDateTime.MIN, as that produces a negative year and there
+    // are representations of the '-' (minus) symbol which lexicographically come after numbers
+    // do in ASCII and we don't want to risk it resulting in this date being considered the
+    // latest date
+    const val DEFAULT_DATE_TIME_FOR_NULL_VALUE = "1200-01-01T00:00:00.000"
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/testutil/TestDataHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/testutil/TestDataHelper.kt
@@ -22,6 +22,9 @@ fun randomDouble(): Double {
   return Random.Default.nextDouble()
 }
 
+/**
+ * Produces a random date between 1970-01-01 and 2150-12-31
+ */
 fun randomLocalDate(): LocalDate {
   val minDay = 0L
   val maxDay = LocalDate.of(2150, 12, 31).toEpochDay()
@@ -29,6 +32,9 @@ fun randomLocalDate(): LocalDate {
   return LocalDate.ofEpochDay(randomDay)
 }
 
+/**
+ * Produces a random date and time between 1970-01-01T00:00:00 and 2150-12-31T23:59:59
+ */
 fun randomLocalDateTime(): LocalDateTime {
   val minSecond = 0L
   val maxSecond = LocalDateTime.of(2150, 12, 31, 23, 59).toEpochSecond(ZoneOffset.UTC)


### PR DESCRIPTION
The DEFAULT_DATE_TIME_FOR_NULL_VALUE is used whenever comparisons of entities by a date time is needed. Any entity with a null date time will be considered to have said constant as its date and time instead. The constant was set to epoch (1970-01-01T00:00:00) with the intention of null-date entities being considered older than those with non-null dates. This is being changed to an earlier date (in 1200), as there's still a (remote) possibility that an offender has an entity associated to them in the DB (e.g. an OSP assessment) earlier than epoch, which could result in incorrect ordering. This was noticed when a test using random values (RiskScoreConverterTest) produced early enough dates to result in unexpected ordering.

Note that using LocalDateTime.MIN.toString() was considered, but at the time of writing that returns a negative year. The '-' (minus) symbol can be represented with several different characters in ASCII, some of which have a greater lexicographic value than numbers do. Since the date time comparisons are done in strings, it was considered to be safer to use 1200 instead.