### PR TITLE
MRD-2526 Fixing info endpoint (move to standard port)

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -105,8 +105,6 @@ housekeeping:
   sendDomainEvents: false
 
 management:
-  server:
-    port: 8081
   endpoints:
     enabled-by-default: false
     web:


### PR DESCRIPTION
Reverting management endpoints (health/info/prometheus) back to standard HTTP ports.
These were overridden to use 8081 on 03/05/22 by Darren Oakley for MRD-11