### PR TITLE
Mrd 2526 fixing info endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,6 @@ COPY --from=builder --chown=appuser:appgroup /app/applicationinsights.json /app
 COPY --from=builder --chown=appuser:appgroup /app/applicationinsights.dev.json /app
 
 USER 2000
-EXPOSE 8080 8081
+EXPOSE 8080
 
 ENTRYPOINT ["java", "-javaagent:/app/agent.jar", "-jar", "/app/app.jar"]

--- a/docker-compose-e2e.yml
+++ b/docker-compose-e2e.yml
@@ -10,7 +10,7 @@ services:
       - "8080:8080"
       - "8081:8081"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8081/health/ping"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health/ping"]
     environment:
       - SERVER_PORT=8080
       - HMPPS_AUTH_URL=http://hmpps-auth:8080/auth # auth comes from UI docker-compose

--- a/docker-compose-e2e.yml
+++ b/docker-compose-e2e.yml
@@ -8,7 +8,6 @@ services:
     container_name: make-recall-decision-api
     ports:
       - "8080:8080"
-      - "8081:8081"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health/ping"]
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - "8080:8080"
       - "8081:8081"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8081/health/ping"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health/ping"]
     environment:
       - SERVER_PORT=8080
       - HMPPS_AUTH_URL=http://hmpps-auth:8080/auth # auth comes from UI docker-compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
     container_name: make-recall-decision-api
     ports:
       - "8080:8080"
-      - "8081:8081"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health/ping"]
     environment:

--- a/helm_deploy/make-recall-decision-api/values.yaml
+++ b/helm_deploy/make-recall-decision-api/values.yaml
@@ -190,7 +190,7 @@ generic-service:
     enabled: true
     scrapeInterval: 15s
     metricsPath: /prometheus
-    metricsPort: 8081
+    metricsPort: 8080
 
 generic-prometheus-alerts:
   targetApplication: make-recall-decision-api

--- a/scripts/start-local-services.sh
+++ b/scripts/start-local-services.sh
@@ -85,7 +85,7 @@ function wait_for {
 
 wait_for "http://localhost:9090/auth/health/ping" "${AUTH_NAME}"
 wait_for "http://localhost:3000/ping" "${UI_NAME}"
-wait_for "http://localhost:8081/health/readiness" "${API_NAME}"
+wait_for "http://localhost:8080/health/readiness" "${API_NAME}"
 wait_for "http://localhost:9091/health" "gotenberg"
 
 printf "\n\nAll services started.\n\n"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -105,8 +105,6 @@ housekeeping:
   sendDomainEvents: false
 
 management:
-  server:
-    port: 8081
   endpoints:
     enabled-by-default: false
     web:


### PR DESCRIPTION
Reverting management endpoints (health/info/prometheus) back to standard HTTP ports.
These were overridden to use 8081 on 03/05/22 by Darren Oakley for MRD-11