### PR TITLE
MRD-2570 Ensuring we cope with inactive prisons (aka Progress Booking On when no Index Offence in NOMIS)

### DIFF
--- a/fake-prison-api/__files/get-agency-MDI.json
+++ b/fake-prison-api/__files/get-agency-MDI.json
@@ -1,22 +1,12 @@
 {
   "agencyId": "MDI",
-  "description": "MOORLAND (HMP & YOI)",
-  "formattedDescription": "Moorland (HMP & YOI)",
+  "description": "Moorland (HMP & YOI)",
+  "longDescription": "Moorland (HMP & YOI)",
   "agencyType": "INST",
-  "addressType": "string",
-  "premise": "string",
-  "locality": "string",
-  "city": "string",
-  "country": "string",
-  "postCode": "string",
-  "phones": [
-    {
-      "phoneId": 2234232,
-      "number": "0114 2345678",
-      "type": "TEL",
-      "ext": "123"
-    }
-  ],
+  "active": true,
+  "courtType": "CC",
+  "courtTypeDescription": "Crown Court",
+  "deactivationDate": "2012-01-12",
   "addresses": [
     {
       "addressId": 543524,
@@ -26,12 +16,16 @@
       "street": "Slinn Street",
       "locality": "Brincliffe",
       "town": "Liverpool",
+      "townCode": "17743",
       "postalCode": "LI1 5TH",
-      "county": "HEREFORD",
-      "country": "ENG",
+      "county": "Herefordshire",
+      "countyCode": "HEREFORD",
+      "country": "England",
+      "countryCode": "ENG",
       "comment": "This is a comment text",
-      "primary": false,
-      "noFixedAddress": false,
+      "primary": "Y",
+      "mail": "Y",
+      "noFixedAddress": "N",
       "startDate": "2005-05-12",
       "endDate": "2021-02-12",
       "phones": [
@@ -51,5 +45,26 @@
         }
       ]
     }
-  ]
+  ],
+  "phones": [
+    {
+      "phoneId": 2234232,
+      "number": "0114 2345678",
+      "type": "TEL",
+      "ext": "123"
+    }
+  ],
+  "emails": [
+    {
+      "email": "string"
+    }
+  ],
+  "area": {
+    "code": "code",
+    "description": "description"
+  },
+  "region": {
+    "code": "code",
+    "description": "description"
+  }
 }

--- a/fake-prison-api/mappings/get-agency-MDI.json
+++ b/fake-prison-api/mappings/get-agency-MDI.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "GET",
-    "urlPath": "/api/agencies/prison/MDI"
+    "urlPath": "/api/agencies/MDI"
   },
   "response": {
     "status": 200,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/client/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/client/PrisonApiClient.kt
@@ -110,12 +110,12 @@ class PrisonApiClient(
     }
   }
 
-  fun retrieveAgency(agencyId: String, activeOnly: Boolean = false): Mono<Agency> {
+  fun retrieveAgency(agencyId: String): Mono<Agency> {
     val responseType = object : ParameterizedTypeReference<Agency>() {}
     return webClient
       .get()
       .uri { builder ->
-        builder.path("/api/agencies/$agencyId?activeOnly=$activeOnly").build()
+        builder.path("/api/agencies/$agencyId").queryParam("activeOnly", false).build()
       }
       .retrieve()
       .onStatus(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/client/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/client/PrisonApiClient.kt
@@ -110,12 +110,12 @@ class PrisonApiClient(
     }
   }
 
-  fun retrieveAgency(agencyId: String): Mono<Agency> {
+  fun retrieveAgency(agencyId: String, activeOnly: Boolean = false): Mono<Agency> {
     val responseType = object : ParameterizedTypeReference<Agency>() {}
     return webClient
       .get()
       .uri { builder ->
-        builder.path("/api/agencies/prison/" + agencyId).build()
+        builder.path("/api/agencies/$agencyId?activeOnly=$activeOnly").build()
       }
       .retrieve()
       .onStatus(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/Agency.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/Agency.kt
@@ -3,6 +3,6 @@ package uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldeci
 data class Agency(
   val agencyId: String? = null,
   val description: String? = null,
-  val formattedDescription: String? = null,
+  val longDescription: String? = null,
   val agencyType: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/PrisonerApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/PrisonerApiService.kt
@@ -51,7 +51,7 @@ internal class PrisonerApiService(
           val movement = t.movementDates.find { it.dateOutOfPrison === lastDateOutOfPrison }
           val prisonDescription = movement?.releaseFromPrisonId?.let {
             try {
-              prisonApiClient.retrieveAgency(movement.releaseFromPrisonId, activeOnly = false).block()?.formattedDescription
+              prisonApiClient.retrieveAgency(movement.releaseFromPrisonId).block()?.longDescription
             } catch (notFoundEx: NotFoundException) {
               log.info("Agency with id ${movement.releaseFromPrisonId} not found: ${notFoundEx.message}")
               null

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/client/PrisonApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/client/PrisonApiClientTest.kt
@@ -114,7 +114,9 @@ class PrisonApiClientTest : IntegrationTestBase() {
 
   @Test
   fun `retrieve agency`() {
-    val request = HttpRequest.request().withPath("/api/agencies/MDI")
+    val request = HttpRequest.request()
+      .withPath("/api/agencies/MDI")
+      .withQueryStringParameter("activeOnly", "false")
 
     prisonApi.`when`(request).respond(
       HttpResponse.response().withContentType(MediaType.APPLICATION_JSON)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/client/PrisonApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/client/PrisonApiClientTest.kt
@@ -113,29 +113,15 @@ class PrisonApiClientTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `retrieve agency, including inactive`() {
-    val request = HttpRequest.request().withPath("/api/agencies/MDI%3FactiveOnly=false")
+  fun `retrieve agency`() {
+    val request = HttpRequest.request().withPath("/api/agencies/MDI")
 
     prisonApi.`when`(request).respond(
       HttpResponse.response().withContentType(MediaType.APPLICATION_JSON)
         .withBody(agencyResponse("MDI")),
     )
 
-    val agency = prisonApiClient.retrieveAgency("MDI", false).block()
-
-    assertThat(agency?.agencyId, equalTo("MDI"))
-  }
-
-  @Test
-  fun `retrieve agency, active only`() {
-    val request = HttpRequest.request().withPath("/api/agencies/MDI%3FactiveOnly=true")
-
-    prisonApi.`when`(request).respond(
-      HttpResponse.response().withContentType(MediaType.APPLICATION_JSON)
-        .withBody(agencyResponse("MDI")),
-    )
-
-    val agency = prisonApiClient.retrieveAgency("MDI", true).block()
+    val agency = prisonApiClient.retrieveAgency("MDI").block()
 
     assertThat(agency?.agencyId, equalTo("MDI"))
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/client/PrisonApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/client/PrisonApiClientTest.kt
@@ -113,22 +113,36 @@ class PrisonApiClientTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `retrieve agency`() {
-    val request = HttpRequest.request().withPath("/api/agencies/prison/MDI")
+  fun `retrieve agency, including inactive`() {
+    val request = HttpRequest.request().withPath("/api/agencies/MDI%3FactiveOnly=false")
 
     prisonApi.`when`(request).respond(
       HttpResponse.response().withContentType(MediaType.APPLICATION_JSON)
         .withBody(agencyResponse("MDI")),
     )
 
-    val agency = prisonApiClient.retrieveAgency("MDI").block()
+    val agency = prisonApiClient.retrieveAgency("MDI", false).block()
+
+    assertThat(agency?.agencyId, equalTo("MDI"))
+  }
+
+  @Test
+  fun `retrieve agency, active only`() {
+    val request = HttpRequest.request().withPath("/api/agencies/MDI%3FactiveOnly=true")
+
+    prisonApi.`when`(request).respond(
+      HttpResponse.response().withContentType(MediaType.APPLICATION_JSON)
+        .withBody(agencyResponse("MDI")),
+    )
+
+    val agency = prisonApiClient.retrieveAgency("MDI", true).block()
 
     assertThat(agency?.agencyId, equalTo("MDI"))
   }
 
   @Test
   fun `agency not found`() {
-    val request = HttpRequest.request().withPath("/api/agencies/prison/MDI")
+    val request = HttpRequest.request().withPath("/api/agencies/MDI")
 
     prisonApi.`when`(request).respond(
       HttpResponse.response().withStatusCode(404),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/PrisonerApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/PrisonerApiServiceTest.kt
@@ -319,8 +319,10 @@ internal class PrisonerApiServiceTest : ServiceTestBase() {
 
     val result = PrisonerApiService(prisonApiClient).retrieveOffences(nomsId)
 
-    val offences = result.get(0).offences
+    val offences = result[0].offences
     assertThat(offences.size).isGreaterThan(0)
+    assertThat(offences[0].offenceDescription).isEqualTo("ABC")
+    assertThat(result[0].releasingPrison).isNull()
   }
 
   @Test
@@ -370,7 +372,7 @@ internal class PrisonerApiServiceTest : ServiceTestBase() {
     given(prisonApiClient.retrieveAgency("A1234")).willReturn(
       Mono.fromCallable {
         Agency(
-          formattedDescription = "Hogwarts",
+          longDescription = "Hogwarts",
         )
       },
     )


### PR DESCRIPTION
Changing the endpoint used to retrieve prison/agency details by prisonId because the new endpoint facilitates querying inactive prisons (a possible scenario).