### PR TITLE
MRD-2610 Combining duplicate mintes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/CreateRecallRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/CreateRecallRequest.kt
@@ -11,5 +11,4 @@ data class CreateRecallRequest(
   val probationArea: String,
   val receivedDateTime: LocalDateTime,
   val riskOfContrabandDetails: String = "",
-  val riskOfSeriousHarmLevel: RiskOfSeriousHarmLevel,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/PpudCreateRecallRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/PpudCreateRecallRequest.kt
@@ -12,13 +12,4 @@ data class PpudCreateRecallRequest(
   val receivedDateTime: LocalDateTime,
   val recommendedTo: PpudUser = PpudUser("", ""),
   val riskOfContrabandDetails: String = "",
-  val riskOfSeriousHarmLevel: RiskOfSeriousHarmLevel,
 )
-
-enum class RiskOfSeriousHarmLevel(val descriptor: String) {
-  Low("Low"),
-  Medium("Medium"),
-  High("High"),
-  VeryHigh("Very High"),
-  NotApplicable("Not Applicable"),
-}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/PpudService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/PpudService.kt
@@ -131,7 +131,6 @@ internal class PpudService(
           receivedDateTime = convertToLondonTimezone(createRecallRequest.receivedDateTime),
           recommendedTo = ppudUser,
           riskOfContrabandDetails = createRecallRequest.riskOfContrabandDetails,
-          riskOfSeriousHarmLevel = createRecallRequest.riskOfSeriousHarmLevel,
         ),
       ),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/client/PpudAutomationApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/client/PpudAutomationApiClientTest.kt
@@ -24,7 +24,6 @@ import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecis
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudUploadMandatoryDocumentRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudUser
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudUserSearchRequest
-import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.RiskOfSeriousHarmLevel
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.SentenceLength
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.IntegrationTestBase
 import java.time.LocalDate
@@ -297,7 +296,6 @@ class PpudAutomationApiClientTest : IntegrationTestBase() {
         receivedDateTime = LocalDateTime.of(2024, 1, 1, 14, 0),
         recommendedTo = PpudUser("", ""),
         riskOfContrabandDetails = "some details",
-        riskOfSeriousHarmLevel = RiskOfSeriousHarmLevel.High,
       ),
     ).block()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/controller/PpudControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/controller/PpudControllerTest.kt
@@ -23,7 +23,6 @@ import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecis
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudUser
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudUserSearchRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudYearMonth
-import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.RiskOfSeriousHarmLevel
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.SentenceLength
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.UploadAdditionalDocumentRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.UploadMandatoryDocumentRequest
@@ -367,7 +366,6 @@ class PpudControllerTest : IntegrationTestBase() {
           probationArea = "probation area",
           receivedDateTime = LocalDateTime.of(2024, 1, 1, 14, 0),
           riskOfContrabandDetails = "some details",
-          riskOfSeriousHarmLevel = RiskOfSeriousHarmLevel.High,
         ),
       )
         .expectStatus().isOk

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/PpudServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/PpudServiceTest.kt
@@ -41,7 +41,6 @@ import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecis
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudUploadAdditionalDocumentRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudUploadMandatoryDocumentRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudUser
-import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.RiskOfSeriousHarmLevel
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.UploadAdditionalDocumentRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.UploadMandatoryDocumentRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.exception.NotFoundException
@@ -223,7 +222,6 @@ internal class PpudServiceTest : ServiceTestBase() {
       probationArea = "probation area",
       receivedDateTime = LocalDateTime.of(2024, 6, 1, 14, 0),
       riskOfContrabandDetails = "some details",
-      riskOfSeriousHarmLevel = RiskOfSeriousHarmLevel.High,
     )
 
     val response = mock(PpudCreateRecallResponse::class.java)
@@ -253,7 +251,6 @@ internal class PpudServiceTest : ServiceTestBase() {
     assertThat(ppudCreateRecallRequest.probationArea).isEqualTo("probation area")
     assertThat(ppudCreateRecallRequest.receivedDateTime).isEqualTo(LocalDateTime.of(2024, 6, 1, 15, 0))
     assertThat(ppudCreateRecallRequest.riskOfContrabandDetails).isEqualTo("some details")
-    assertThat(ppudCreateRecallRequest.riskOfSeriousHarmLevel).isEqualTo(RiskOfSeriousHarmLevel.High)
   }
 
   @Test
@@ -267,7 +264,6 @@ internal class PpudServiceTest : ServiceTestBase() {
       probationArea = "probation area",
       receivedDateTime = LocalDateTime.of(2024, 1, 1, 14, 0),
       riskOfContrabandDetails = "some details",
-      riskOfSeriousHarmLevel = RiskOfSeriousHarmLevel.High,
     )
 
     val ex = assertThrows<NotFoundException> {


### PR DESCRIPTION
Removing all referenced to the ROSHLevel no longer passed when creating a recall since the ppud minutes that it previously created are now created from an individual call from the UI, not PPUD API