### PR TITLE
Mrd 2650 remove unused book recall endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/client/ppud/PpudAutomationApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/client/ppud/PpudAutomationApiClient.kt
@@ -12,8 +12,6 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.config.WebClientConfiguration.Companion.withRetry
-import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudBookRecall
-import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudBookRecallResponse
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudCreateMinuteRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudCreateOffenderRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudCreateOffenderResponse
@@ -51,10 +49,6 @@ class PpudAutomationApiClient(
 
   fun details(id: String): Mono<PpudDetailsResponse> {
     return get("/offender/$id", object : ParameterizedTypeReference<PpudDetailsResponse>() {})
-  }
-
-  fun bookToPpud(nomisId: String, request: PpudBookRecall): Mono<PpudBookRecallResponse> {
-    return post("/offender/$nomisId/recall", request, object : ParameterizedTypeReference<PpudBookRecallResponse>() {})
   }
 
   fun createOffender(request: PpudCreateOffenderRequest): Mono<PpudCreateOffenderResponse> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/controller/PpudController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/controller/PpudController.kt
@@ -12,8 +12,6 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.CreateMinuteRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.CreateRecallRequest
-import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudBookRecall
-import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudBookRecallResponse
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudCreateOffenderRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudCreateOffenderResponse
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudCreateOrUpdateReleaseRequest
@@ -60,17 +58,6 @@ internal class PpudController(
     @PathVariable("id") id: String,
   ): PpudDetailsResponse {
     return ppudService.details(id)
-  }
-
-  // TODO: MRD-2650 - This endpoint looks like it's no longer used. Double check and remove.
-  @PreAuthorize("hasRole('ROLE_MAKE_RECALL_DECISION')")
-  @PostMapping("/ppud/book-recall/{nomisId}")
-  @Operation(summary = "Calls PPUD Automation service to book recall.")
-  suspend fun bookRecall(
-    @PathVariable("nomisId") nomisId: String,
-    @RequestBody request: PpudBookRecall,
-  ): PpudBookRecallResponse {
-    return ppudService.bookToPpud(nomisId, request)
   }
 
   @PreAuthorize("hasRole('ROLE_MAKE_RECALL_DECISION')")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/CreateRecallRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/CreateRecallRequest.kt
@@ -11,5 +11,4 @@ data class CreateRecallRequest(
   val probationArea: String,
   val receivedDateTime: LocalDateTime,
   val riskOfContrabandDetails: String = "",
-  val riskOfSeriousHarmLevel: RiskOfSeriousHarmLevel,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/PpudBookRecallResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/PpudBookRecallResponse.kt
@@ -1,5 +1,0 @@
-package uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions
-
-data class PpudBookRecallResponse(
-  val recall: PpudRecallSummary,
-)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/PpudCreateRecallRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/PpudCreateRecallRequest.kt
@@ -12,13 +12,4 @@ data class PpudCreateRecallRequest(
   val receivedDateTime: LocalDateTime,
   val recommendedTo: PpudUser = PpudUser("", ""),
   val riskOfContrabandDetails: String = "",
-  val riskOfSeriousHarmLevel: RiskOfSeriousHarmLevel,
 )
-
-enum class RiskOfSeriousHarmLevel(val descriptor: String) {
-  Low("Low"),
-  Medium("Medium"),
-  High("High"),
-  VeryHigh("Very High"),
-  NotApplicable("Not Applicable"),
-}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/PpudRecallSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/PpudRecallSummary.kt
@@ -1,5 +1,0 @@
-package uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions
-
-data class PpudRecallSummary(
-  val id: String,
-)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/PpudService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/PpudService.kt
@@ -6,8 +6,6 @@ import uk.gov.justice.digital.hmpps.makerecalldecisionapi.client.ppud.PpudAutoma
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.CreateMinuteRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.CreateRecallRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.DocumentCategory
-import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudBookRecall
-import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudBookRecallResponse
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudCreateMinuteRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudCreateOffenderRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudCreateOffenderResponse
@@ -52,13 +50,6 @@ internal class PpudService(
   fun details(id: String): PpudDetailsResponse {
     val response = getValueAndHandleWrappedException(
       ppudAutomationApiClient.details(id),
-    )
-    return response!!
-  }
-
-  fun bookToPpud(nomisId: String, payload: PpudBookRecall): PpudBookRecallResponse {
-    val response = getValueAndHandleWrappedException(
-      ppudAutomationApiClient.bookToPpud(nomisId, payload),
     )
     return response!!
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/PpudService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/PpudService.kt
@@ -131,7 +131,6 @@ internal class PpudService(
           receivedDateTime = convertToLondonTimezone(createRecallRequest.receivedDateTime),
           recommendedTo = ppudUser,
           riskOfContrabandDetails = createRecallRequest.riskOfContrabandDetails,
-          riskOfSeriousHarmLevel = createRecallRequest.riskOfSeriousHarmLevel,
         ),
       ),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/client/PpudAutomationApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/client/PpudAutomationApiClientTest.kt
@@ -8,7 +8,6 @@ import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.client.ppud.PpudAutomationApiClient
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.DocumentCategory
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudAddress
-import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudBookRecall
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudContact
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudContactWithTelephone
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudCreateMinuteRequest
@@ -69,36 +68,6 @@ class PpudAutomationApiClientTest : IntegrationTestBase() {
 
     // then
     assertThat(actual?.offender?.id, equalTo(id))
-  }
-
-  @Test
-  fun `book recall to ppud`() {
-    // given
-    val id = "12345678"
-    val nomsId = "AB234A"
-
-    ppudAutomationBookRecallApiMatchResponse(nomsId, id)
-
-    // when
-    val actual = ppudAutomationApiClient.bookToPpud(
-      nomsId,
-      PpudBookRecall(
-        LocalDateTime.of(2023, 11, 1, 12, 5, 10),
-        isInCustody = true,
-        mappaLevel = "Level 3 – MAPPP",
-        policeForce = "Kent Police",
-        probationArea = "Merseyside",
-        recommendedTo = PpudUser("Consider a Recall Test", "Recall 1"),
-        receivedDateTime = LocalDateTime.of(2023, 11, 20, 11, 30),
-        releaseDate = LocalDate.of(2023, 11, 5),
-        riskOfContrabandDetails = "Smuggling in cigarettes",
-        riskOfSeriousHarmLevel = "Low",
-        sentenceDate = LocalDate.of(2023, 11, 4),
-      ),
-    ).block()
-
-    // then
-    assertThat(actual?.recall?.id, equalTo("12345678"))
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/client/PpudAutomationApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/client/PpudAutomationApiClientTest.kt
@@ -24,7 +24,6 @@ import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecis
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudUploadMandatoryDocumentRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudUser
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudUserSearchRequest
-import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.RiskOfSeriousHarmLevel
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.SentenceLength
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.IntegrationTestBase
 import java.time.LocalDate
@@ -297,7 +296,6 @@ class PpudAutomationApiClientTest : IntegrationTestBase() {
         receivedDateTime = LocalDateTime.of(2024, 1, 1, 14, 0),
         recommendedTo = PpudUser("", ""),
         riskOfContrabandDetails = "some details",
-        riskOfSeriousHarmLevel = RiskOfSeriousHarmLevel.High,
       ),
     ).block()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/controller/PpudControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/controller/PpudControllerTest.kt
@@ -23,7 +23,6 @@ import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecis
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudUser
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudUserSearchRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudYearMonth
-import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.RiskOfSeriousHarmLevel
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.SentenceLength
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.UploadAdditionalDocumentRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.UploadMandatoryDocumentRequest
@@ -367,7 +366,6 @@ class PpudControllerTest : IntegrationTestBase() {
           probationArea = "probation area",
           receivedDateTime = LocalDateTime.of(2024, 1, 1, 14, 0),
           riskOfContrabandDetails = "some details",
-          riskOfSeriousHarmLevel = RiskOfSeriousHarmLevel.High,
         ),
       )
         .expectStatus().isOk

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/controller/PpudControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/controller/PpudControllerTest.kt
@@ -11,7 +11,6 @@ import org.springframework.web.reactive.function.BodyInserters
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.CreateMinuteRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.CreateRecallRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudAddress
-import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudBookRecall
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudContact
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudContactWithTelephone
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudCreateOffenderRequest
@@ -20,7 +19,6 @@ import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecis
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudUpdateOffenceRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudUpdateOffenderRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudUpdatePostRelease
-import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudUser
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudUserSearchRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudYearMonth
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.SentenceLength
@@ -98,30 +96,6 @@ class PpudControllerTest : IntegrationTestBase() {
       .contentType(MediaType.APPLICATION_JSON)
       .body(BodyInserters.fromValue(requestBody))
       .exchange()
-
-  @Test
-  fun `book recall`() {
-    ppudAutomationBookRecallApiMatchResponse("A1234AB", "12345678")
-    runTest {
-      postToBookRecall(
-        "A1234AB",
-        PpudBookRecall(
-          LocalDateTime.of(2023, 11, 1, 12, 5, 10),
-          isInCustody = true,
-          mappaLevel = "Level 3 – MAPPP",
-          policeForce = "Kent Police",
-          probationArea = "Merseyside",
-          recommendedTo = PpudUser("Consider a Recall Test", "Recall 1"),
-          receivedDateTime = LocalDateTime.of(2023, 11, 20, 11, 30),
-          releaseDate = LocalDate.of(2023, 11, 5),
-          riskOfContrabandDetails = "Smuggling in cigarettes",
-          riskOfSeriousHarmLevel = "Low",
-          sentenceDate = LocalDate.of(2023, 11, 4),
-        ),
-      )
-        .expectStatus().isOk
-    }
-  }
 
   @Test
   fun `ppud create offender`() {
@@ -497,14 +471,6 @@ class PpudControllerTest : IntegrationTestBase() {
   private fun postToSearchActiveUsers(requestBody: PpudUserSearchRequest): WebTestClient.ResponseSpec =
     webTestClient.post()
       .uri("/ppud/user/search")
-      .headers { it.authToken(roles = listOf("ROLE_MAKE_RECALL_DECISION")) }
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(BodyInserters.fromValue(requestBody))
-      .exchange()
-
-  private fun postToBookRecall(nomisId: String, requestBody: PpudBookRecall): WebTestClient.ResponseSpec =
-    webTestClient.post()
-      .uri("/ppud/book-recall/$nomisId")
       .headers { it.authToken(roles = listOf("ROLE_MAKE_RECALL_DECISION")) }
       .contentType(MediaType.APPLICATION_JSON)
       .body(BodyInserters.fromValue(requestBody))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/PpudServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/PpudServiceTest.kt
@@ -21,8 +21,6 @@ import uk.gov.justice.digital.hmpps.makerecalldecisionapi.client.ppud.PpudAutoma
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.CreateMinuteRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.CreateRecallRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.DocumentCategory
-import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudBookRecall
-import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudBookRecallResponse
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudCreateMinuteRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudCreateOffenderRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudCreateOffenderResponse
@@ -95,23 +93,6 @@ internal class PpudServiceTest : ServiceTestBase() {
     )
 
     val result = ppudService.details("12345678")
-
-    assertThat(result).isEqualTo(response)
-  }
-
-  @Test
-  fun `call book to ppud`() {
-    val request = mock(PpudBookRecall::class.java)
-
-    val response = mock(PpudBookRecallResponse::class.java)
-
-    given(ppudAutomationApiClient.bookToPpud("123", request)).willReturn(
-      Mono.fromCallable {
-        response
-      },
-    )
-
-    val result = ppudService.bookToPpud("123", request)
 
     assertThat(result).isEqualTo(response)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/PpudServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/PpudServiceTest.kt
@@ -41,7 +41,6 @@ import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecis
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudUploadAdditionalDocumentRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudUploadMandatoryDocumentRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PpudUser
-import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.RiskOfSeriousHarmLevel
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.UploadAdditionalDocumentRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.UploadMandatoryDocumentRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.exception.NotFoundException
@@ -223,7 +222,6 @@ internal class PpudServiceTest : ServiceTestBase() {
       probationArea = "probation area",
       receivedDateTime = LocalDateTime.of(2024, 6, 1, 14, 0),
       riskOfContrabandDetails = "some details",
-      riskOfSeriousHarmLevel = RiskOfSeriousHarmLevel.High,
     )
 
     val response = mock(PpudCreateRecallResponse::class.java)
@@ -253,7 +251,6 @@ internal class PpudServiceTest : ServiceTestBase() {
     assertThat(ppudCreateRecallRequest.probationArea).isEqualTo("probation area")
     assertThat(ppudCreateRecallRequest.receivedDateTime).isEqualTo(LocalDateTime.of(2024, 6, 1, 15, 0))
     assertThat(ppudCreateRecallRequest.riskOfContrabandDetails).isEqualTo("some details")
-    assertThat(ppudCreateRecallRequest.riskOfSeriousHarmLevel).isEqualTo(RiskOfSeriousHarmLevel.High)
   }
 
   @Test
@@ -267,7 +264,6 @@ internal class PpudServiceTest : ServiceTestBase() {
       probationArea = "probation area",
       receivedDateTime = LocalDateTime.of(2024, 1, 1, 14, 0),
       riskOfContrabandDetails = "some details",
-      riskOfSeriousHarmLevel = RiskOfSeriousHarmLevel.High,
     )
 
     val ex = assertThrows<NotFoundException> {


### PR DESCRIPTION
Removing a deprecated endpoint whilst I was working in the area.
This project's 
`/ppud/book-recall/{nomisId `
call was being proxied on to PPUD API's
`/offender/$nomisId/recall`
but neither were called from the UI