### PR TITLE
Mrd 2634 caching lao calls

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
   kotlin("plugin.jpa") version "2.0.21"
   id("org.sonarqube") version "6.0.1.5171"
   kotlin("plugin.spring") version "2.0.21"
+  kotlin("plugin.serialization") version "2.0.21"
 }
 
 jacoco.toolVersion = "0.8.11"
@@ -33,6 +34,8 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
   implementation("org.springframework.boot:spring-boot-starter-actuator:3.4.1")
+  implementation("org.springframework.boot:spring-boot-starter-cache")
+  implementation("org.springframework.boot:spring-boot-starter-data-redis")
   implementation("io.micrometer:micrometer-registry-prometheus:1.14.3")
   implementation("io.opentelemetry:opentelemetry-api:1.46.0")
   implementation("joda-time:joda-time:2.13.0")

--- a/docker-compose-e2e.yml
+++ b/docker-compose-e2e.yml
@@ -55,6 +55,17 @@ services:
       - POSTGRES_USER=mrd_user
       - POSTGRES_DB=make_recall_decision
 
+  redis:
+    image: redis:7.4.2-alpine3.21
+    ports:
+      - 6369:6369
+    expose:
+      - 6369
+    networks:
+      - hmpps
+    command:
+      --port 6369
+
   fake-offender-search-api:
     image: wiremock/wiremock
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,17 @@ services:
       - POSTGRES_USER=mrd_user
       - POSTGRES_DB=make_recall_decision
 
+  redis:
+    image: redis:7.4.2-alpine3.21
+    ports:
+      - 6369:6369
+    expose:
+      - 6369
+    networks:
+      - hmpps
+    command:
+      --port 6369
+
   fake-offender-search-api:
     image: wiremock/wiremock
     networks:

--- a/helm_deploy/make-recall-decision-api/values.yaml
+++ b/helm_deploy/make-recall-decision-api/values.yaml
@@ -40,6 +40,7 @@ generic-service:
     SENTRY_DSN: https://d51aaaaf56b547b8b0582ed0af80bdb7@o345774.ingest.sentry.io/6361157
     GOTENBERG_ENDPOINT_URL: http://make-recall-decision-api-gotenberg
     HMPPS_SQS_USE_WEB_TOKEN: "true"
+    REDIS_CACHING_ENABLED: "true"
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:
@@ -58,6 +59,9 @@ generic-service:
       POSTGRES_PASSWORD: "password"
     hmpps-domain-events-topic:
       HMPPS_DOMAIN_EVENT_TOPIC_ARN: "topic_arn"
+    elasticache-redis:
+      SPRING_DATA_REDIS_HOST: "primary_endpoint_address"
+      SPRING_DATA_REDIS_PASSWORD: "auth_token"
 
   allowlist:
     north_shields_user: 194.33.192.1/24

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/config/CacheConstants.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/config/CacheConstants.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.makerecalldecisionapi.config
+
+object CacheConstants {
+  const val USER_ACCESS_CACHE_KEY = "USER_ACCESS"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/UserAccessValidator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/UserAccessValidator.kt
@@ -1,13 +1,17 @@
 package uk.gov.justice.digital.hmpps.makerecalldecisionapi.service
 
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.client.DeliusClient
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.client.DeliusClient.UserAccess
+import uk.gov.justice.digital.hmpps.makerecalldecisionapi.config.CacheConstants.USER_ACCESS_CACHE_KEY
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.exception.PersonNotFoundException
 
 @Component
 internal class UserAccessValidator(private val deliusClient: DeliusClient) {
+
+  @Cacheable(USER_ACCESS_CACHE_KEY)
   fun checkUserAccess(
     crn: String,
     username: String = SecurityContextHolder.getContext().authentication.name,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -61,13 +61,14 @@ spring:
             client-id: ${system.client.id:make-recall-decision-api}
             client-secret: ${system.client.secret:clientsecret}
             authorization-grant-type: client_credentials
-
         provider:
           hmpps-auth:
             token-uri: ${hmpps.auth.url}/oauth/token
       resourceserver:
         jwt:
           jwk-set-uri: ${hmpps.auth.url}/.well-known/jwks.json
+  cache:
+    type: redis
 
   jackson:
     parser:
@@ -86,6 +87,12 @@ spring:
     group:
       test:
         - "stdout"
+
+  data:
+    redis:
+      port: 6369
+      repositories:
+        enabled: false
 
 server:
   port: 8080
@@ -191,9 +198,9 @@ prison:
 
 ---
 mrd:
-  url: ${mrd.url}
+  url:
   api:
-    url: ${mrd.api.url}
+    url:
 
 cloud:
   aws:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/controller/CaseOverviewControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/controller/CaseOverviewControllerTest.kt
@@ -3,12 +3,17 @@ package uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.controlle
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.cache.CacheManager
+import org.springframework.cache.get
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.makerecalldecisionapi.config.CacheConstants.USER_ACCESS_CACHE_KEY
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.helper.isNull
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.jpa.entity.Status
@@ -22,6 +27,14 @@ class CaseOverviewControllerTest(
   @Value("\${oasys.arn.client.timeout}") private val oasysArnClientTimeout: Long,
   @Value("\${ndelius.client.timeout}") private val nDeliusTimeout: Long,
 ) : IntegrationTestBase() {
+
+  @Autowired
+  lateinit var cacheManager: CacheManager
+
+  @BeforeEach
+  fun setup() {
+    cacheManager[USER_ACCESS_CACHE_KEY]?.invalidate()
+  }
 
   @ParameterizedTest
   @CsvSource("REC_CLOSED,false", "SOME_OPEN_STATUS,true")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/controller/LicenceConditionsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/controller/LicenceConditionsControllerTest.kt
@@ -4,10 +4,15 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.json.JSONObject
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.cache.CacheManager
+import org.springframework.cache.get
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.makerecalldecisionapi.config.CacheConstants.USER_ACCESS_CACHE_KEY
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.jpa.entity.Status
 import java.time.LocalDate
@@ -20,6 +25,14 @@ class LicenceConditionsControllerTest(
   @Value("\${ndelius.client.timeout}") private val nDeliusTimeout: Long,
   @Value("\${cvl.client.timeout}") private val cvlTimeout: Long,
 ) : IntegrationTestBase() {
+
+  @Autowired
+  lateinit var cacheManager: CacheManager
+
+  @BeforeEach
+  fun setup() {
+    cacheManager[USER_ACCESS_CACHE_KEY]?.invalidate()
+  }
 
   @Test
   fun `CVL licence null when exception thrown`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/controller/ManagementOversightControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/controller/ManagementOversightControllerTest.kt
@@ -3,16 +3,23 @@ package uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.controlle
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.cache.CacheManager
+import org.springframework.cache.get
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.web.reactive.function.BodyInserters
+import uk.gov.justice.digital.hmpps.makerecalldecisionapi.config.CacheConstants.USER_ACCESS_CACHE_KEY
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.requests.makerecalldecisions.updateRecommendationForNoRecallRequest
 
 @ActiveProfiles("test")
 @ExperimentalCoroutinesApi
 class ManagementOversightControllerTest() : IntegrationTestBase() {
+
+  @Autowired
+  lateinit var cacheManager: CacheManager
 
   @Test
   fun `get management oversight`() {
@@ -91,8 +98,12 @@ class ManagementOversightControllerTest() : IntegrationTestBase() {
     oasysAssessmentsResponse(crn)
     userAccessAllowed(crn)
     personalDetailsResponseOneTimeOnly(crn)
+    // Clear previous cache write
+    cacheManager[USER_ACCESS_CACHE_KEY]?.invalidate()
     licenceConditionsResponse(crn, 2500614567)
     personalDetailsResponseOneTimeOnly(crn)
+    // Clear previous cache write
+    cacheManager[USER_ACCESS_CACHE_KEY]?.invalidate()
     deleteAndCreateRecommendation()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/controller/OffenderSearchControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/controller/OffenderSearchControllerTest.kt
@@ -3,10 +3,14 @@ package uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.controlle
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.cache.CacheManager
+import org.springframework.cache.get
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.web.reactive.function.BodyInserters.fromValue
+import uk.gov.justice.digital.hmpps.makerecalldecisionapi.config.CacheConstants.USER_ACCESS_CACHE_KEY
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.OffenderSearchRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.IntegrationTestBase
 import kotlin.random.Random
@@ -16,6 +20,9 @@ import kotlin.random.Random
 class OffenderSearchControllerTest(
   @Value("\${ndelius.client.timeout}") private val nDeliusTimeout: Long,
 ) : IntegrationTestBase() {
+
+  @Autowired
+  lateinit var cacheManager: CacheManager
 
   @Test
   fun `retrieves simple case summary details using crn`() {
@@ -91,6 +98,8 @@ class OffenderSearchControllerTest(
       val crn = "X123456"
       limitedAccessPractitionerOffenderSearchResponse(crn)
       userAccessExcluded(crn)
+      // Clear previous cache write
+      cacheManager[USER_ACCESS_CACHE_KEY]?.invalidate()
       val requestBody = OffenderSearchRequest(crn = crn)
       webTestClient.post()
         .uri("/paged-search?page=0&pageSize=1")
@@ -160,6 +169,8 @@ class OffenderSearchControllerTest(
       val crn = "X123456"
       limitedAccessPractitionerOffenderSearchResponse(crn)
       userNotFound(crn)
+      // Clear previous cache write
+      cacheManager[USER_ACCESS_CACHE_KEY]?.invalidate()
       val requestBody = OffenderSearchRequest(crn = crn)
       webTestClient.post()
         .uri("/paged-search?page=0&pageSize=1")
@@ -203,6 +214,8 @@ class OffenderSearchControllerTest(
       val crn = "X123456"
       limitedAccessPractitionerOffenderSearchResponse(crn)
       userAccessAllowed(crn, delaySeconds = nDeliusTimeout + 2)
+      // Clear previous cache write
+      cacheManager[USER_ACCESS_CACHE_KEY]?.invalidate()
       val requestBody = OffenderSearchRequest(crn = crn)
       webTestClient.post()
         .uri("/paged-search?page=0&pageSize=1")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/controller/PersonDetailsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/controller/PersonDetailsControllerTest.kt
@@ -3,10 +3,14 @@ package uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.controlle
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.cache.CacheManager
+import org.springframework.cache.get
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.GATEWAY_TIMEOUT
 import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.makerecalldecisionapi.config.CacheConstants.USER_ACCESS_CACHE_KEY
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.jpa.entity.Status
 import java.time.LocalDate
@@ -18,6 +22,9 @@ import java.time.format.DateTimeFormatter
 class PersonDetailsControllerTest(
   @Value("\${ndelius.client.timeout}") private val nDeliusTimeout: Long,
 ) : IntegrationTestBase() {
+
+  @Autowired
+  lateinit var cacheManager: CacheManager
 
   @Test
   fun `retrieves person details`() {
@@ -79,6 +86,8 @@ class PersonDetailsControllerTest(
   fun `handles scenario where no person exists matching crn`() {
     runTest {
       userAccessAllowed(crn)
+      // Clear previous cache write
+      cacheManager[USER_ACCESS_CACHE_KEY]?.invalidate()
       personalDetailsNotFound(crn)
 
       webTestClient.get()
@@ -98,7 +107,8 @@ class PersonDetailsControllerTest(
   fun `given case is excluded then only return user access details`() {
     runTest {
       userAccessRestricted(crn)
-
+      // Clear previous cache write
+      cacheManager[USER_ACCESS_CACHE_KEY]?.invalidate()
       webTestClient.get()
         .uri("/cases/$crn/personal-details")
         .headers { it.authToken(roles = listOf("ROLE_MAKE_RECALL_DECISION")) }
@@ -119,7 +129,8 @@ class PersonDetailsControllerTest(
     runTest {
       userAccessAllowed(crn)
       personalDetailsResponse(crn, delaySeconds = nDeliusTimeout + 2)
-
+      // Clear previous cache write
+      cacheManager[USER_ACCESS_CACHE_KEY]?.invalidate()
       webTestClient.get()
         .uri("/cases/$crn/personal-details")
         .headers { it.authToken(roles = listOf("ROLE_MAKE_RECALL_DECISION")) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/controller/VulnerabilitiesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/controller/VulnerabilitiesControllerTest.kt
@@ -2,9 +2,14 @@ package uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.controlle
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.cache.CacheManager
+import org.springframework.cache.get
 import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.makerecalldecisionapi.config.CacheConstants.USER_ACCESS_CACHE_KEY
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.jpa.entity.Status
 import java.time.LocalDate
@@ -16,6 +21,14 @@ import java.time.format.DateTimeFormatter
 class VulnerabilitiesControllerTest(
   @Value("\${oasys.arn.client.timeout}") private val oasysArnClientTimeout: Long,
 ) : IntegrationTestBase() {
+
+  @Autowired
+  lateinit var cacheManager: CacheManager
+
+  @BeforeEach
+  fun setup() {
+    cacheManager[USER_ACCESS_CACHE_KEY]?.invalidate()
+  }
 
   @Test
   fun `retrieves risk vulnerability details`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/service/UserAccessValidatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/service/UserAccessValidatorTest.kt
@@ -1,0 +1,80 @@
+package uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.service
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.mockserver.model.HttpRequest.request
+import org.mockserver.model.HttpResponse.response
+import org.mockserver.model.MediaType.APPLICATION_JSON
+import org.mockserver.verify.VerificationTimes
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.cache.CacheManager
+import org.springframework.cache.get
+import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.makerecalldecisionapi.config.CacheConstants.USER_ACCESS_CACHE_KEY
+import uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.responses.ndelius.useraccess.userAccessAllowedResponse
+import uk.gov.justice.digital.hmpps.makerecalldecisionapi.service.UserAccessValidator
+
+@ActiveProfiles("test")
+class UserAccessValidatorTest() : IntegrationTestBase() {
+
+  @Autowired
+  private lateinit var userAccessValidator: UserAccessValidator
+
+  @Autowired
+  lateinit var cacheManager: CacheManager
+
+  @Test
+  fun `checks user access - caching test`(@Value("\${spring.cache.type}") isCacheEnabled: String = "none") {
+    runTest {
+      val userName = "SOME_USER"
+
+      val userAccessRequest = request().withPath("/user/$userName/access/$crn")
+      deliusIntegration.`when`(userAccessRequest).respond(
+        response().withContentType(APPLICATION_JSON).withBody(userAccessAllowedResponse()),
+      )
+
+      if (isCacheEnabled.equals("none", ignoreCase = true)) {
+        // First call: cache disabled (miss & no write)
+        userAccessValidator.checkUserAccess(crn, userName)
+
+        deliusIntegration.verify(
+          request()
+            .withPath("/user/$userName/access/$crn"),
+          VerificationTimes.exactly(1),
+        )
+
+        // Second call: cache disabled (miss & no write)
+        userAccessValidator.checkUserAccess(crn, userName)
+
+        deliusIntegration.verify(
+          request()
+            .withPath("/user/$userName/access/$crn"),
+          VerificationTimes.exactly(2),
+        )
+      } else {
+        // Clear any previous cache write
+        cacheManager[USER_ACCESS_CACHE_KEY]?.invalidate()
+
+        // First call: cache miss & write
+        userAccessValidator.checkUserAccess(crn, userName)
+
+        deliusIntegration.verify(
+          request()
+            .withPath("/user/$userName/access/$crn"),
+          VerificationTimes.exactly(1),
+        )
+
+        // Second call: cache hit
+        userAccessValidator.checkUserAccess(crn, userName)
+
+        deliusIntegration.verify(
+          request()
+            .withPath("/user/$userName/access/$crn"),
+          VerificationTimes.exactly(1),
+        )
+      }
+    }
+  }
+}


### PR DESCRIPTION
Additional redis-backed cache config on non-standard port 6369 for single call to limited access offender endpoint.
Also tests for cached endpoint, and updates to additional tests to ignore caching