### PR TITLE
MRD-2639 Make ppudOffender.establishment optional

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/recommendation/PpudOffender.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/recommendation/PpudOffender.kt
@@ -12,7 +12,8 @@ data class PpudOffender(
   val firstNames: String,
   val gender: String,
   val immigrationStatus: String,
-  val establishment: String,
+  // TODO MRD-2693 make establishment field mandatory
+  val establishment: String?,
   val nomsId: String,
   val prisonerCategory: String,
   val prisonNumber: String,


### PR DESCRIPTION
The establishment field in PpudOffender is made nullable/optional to prevent errors when loading older recommendations in the system whose ppudOffender field was retrieved before the establishment field was introduced. A separate ticket has been opened, MRD-2693, to eventually make the field non-nullable.