### PR TITLE
Mrd 2634 CircleCI config for shared redis instance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ executors:
           - POSTGRES_DB=make_recall_decision
           - POSTGRES_PORT=5432
       - image: cimg/redis:7.4.2
-        command: redis-server --port 6369
+        command: redis-server --port 6379
         environment:
           ALLOW_EMPTY_PASSWORD: yes
     working_directory: ~/app

--- a/docker-compose-e2e.yml
+++ b/docker-compose-e2e.yml
@@ -58,13 +58,13 @@ services:
   redis:
     image: redis:7.4.2-alpine3.21
     ports:
-      - 6369:6369
+      - 6379:6379
     expose:
-      - 6369
+      - 6379
     networks:
       - hmpps
     command:
-      --port 6369
+      --port 6379
 
   fake-offender-search-api:
     image: wiremock/wiremock

--- a/docker-compose-integration-test-postgres.yml
+++ b/docker-compose-integration-test-postgres.yml
@@ -30,13 +30,13 @@ services:
   redis:
     image: redis:7.4.2-alpine3.21
     ports:
-      - 6369:6369
+      - 6379:6379
     expose:
-      - 6369
+      - 6379
     networks:
       - hmpps
     command:
-      --port 6369
+      --port 6379
 
 networks:
   postgres:

--- a/docker-compose-postgres.yml
+++ b/docker-compose-postgres.yml
@@ -34,13 +34,13 @@ services:
   redis:
     image: redis:7.4.2-alpine3.21
     ports:
-      - 6369:6369
+      - 6379:6379
     expose:
-      - 6369
+      - 6379
     networks:
       - hmpps
     command:
-      --port 6369
+      --port 6379
 
 networks:
   postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,17 +55,6 @@ services:
       - POSTGRES_USER=mrd_user
       - POSTGRES_DB=make_recall_decision
 
-  redis:
-    image: redis:7.4.2-alpine3.21
-    ports:
-      - 6379:6379
-    expose:
-      - 6379
-    networks:
-      - hmpps
-    command:
-      --port 6379
-
   fake-offender-search-api:
     image: wiremock/wiremock
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,13 +58,13 @@ services:
   redis:
     image: redis:7.4.2-alpine3.21
     ports:
-      - 6369:6369
+      - 6379:6379
     expose:
-      - 6369
+      - 6379
     networks:
       - hmpps
     command:
-      --port 6369
+      --port 6379
 
   fake-offender-search-api:
     image: wiremock/wiremock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
       context: .
     networks:
       - hmpps
-    depends_on:
-      - redis
     container_name: make-recall-decision-api
     ports:
       - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       context: .
     networks:
       - hmpps
+    depends_on:
+      - redis
     container_name: make-recall-decision-api
     ports:
       - "8080:8080"
@@ -12,6 +14,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health/ping"]
     environment:
       - SERVER_PORT=8080
+      - REDIS_HOST=redis
       - HMPPS_AUTH_URL=http://hmpps-auth:8080/auth # auth comes from UI docker-compose
       - OFFENDER_SEARCH_ENDPOINT_URL=http://fake-offender-search-api:8080
       - DELIUS_INTEGRATION_ENDPOINT_URL=http://fake-delius-integration-api:8080

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -74,7 +74,7 @@ spring:
 
   data:
     redis:
-      port: 6369
+      port: 6379
       repositories:
         enabled: false
 


### PR DESCRIPTION
Reverting to standard redis port
Removing the depends_on attribute, retaining the REDIS_HOST env var