### PR TITLE
[MRD-2557]: PPCS e2e local journey

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,7 @@ jobs:
             set +e
 
             npx cypress run \
-              --env TAGS='not @E2E and not @smoke',USERNAME=${CYPRESS_USERNAME_local},PASSWORD=${CYPRESS_PASSWORD_local},USERNAME_SPO=${CYPRESS_USERNAME_SPO_local},PASSWORD_SPO=${CYPRESS_PASSWORD_SPO_local},USERNAME_ACO=${CYPRESS_USERNAME_ACO_local},PASSWORD_ACO=${CYPRESS_PASSWORD_ACO_local} \
+              --env TAGS='not @E2E and not @smoke',USERNAME=${CYPRESS_USERNAME_local},PASSWORD=${CYPRESS_PASSWORD_local},USERNAME_SPO=${CYPRESS_USERNAME_SPO_local},PASSWORD_SPO=${CYPRESS_PASSWORD_SPO_local},USERNAME_ACO=${CYPRESS_USERNAME_ACO_local},PASSWORD_ACO=${CYPRESS_PASSWORD_ACO_local},USERNAME_PPCS=${CYPRESS_USERNAME_PPCS_local},PASSWORD_PPCS=${CYPRESS_PASSWORD_PPCS_local},MAKE_RECALL_DECISION_API_URL=${CYPRESS_MAKE_RECALL_DECISION_API_URL_local},HMPPS_AUTH_EXTERNAL_URL=${CYPRESS_HMPPS_AUTH_EXTERNAL_URL_local} \
               --config-file e2e_tests/cypress.config.ts \
               --browser chrome \
               --record false \

--- a/fake-delius-integration-api/__files/user-info-api.json
+++ b/fake-delius-integration-api/__files/user-info-api.json
@@ -1,0 +1,10 @@
+{
+    "username": "Art Major",
+    "email": "abc@123.com",
+    "staffCode": "TEST01",
+    "name": {
+      "forename": "John",
+      "middleName": null,
+      "surname": "Smith"
+    }
+  }

--- a/fake-delius-integration-api/mappings/user-info-api.json
+++ b/fake-delius-integration-api/mappings/user-info-api.json
@@ -1,0 +1,14 @@
+{
+    "request": {
+      "method": "GET",
+      "urlPathPattern": "/user/make-recall-decision-api details"
+    },
+    "response": {
+      "status": 200,
+      "bodyFileName": "user-info-api.json",
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+  

--- a/fake-ppud-automation-api/__files/search-PPCS_X738925.json
+++ b/fake-ppud-automation-api/__files/search-PPCS_X738925.json
@@ -2,9 +2,9 @@
   "results": [    {
     "id": "4F6666656E64657269643D313731383138G725H664",
     "croNumber": "123456/12A",
-    "nomsId": "JG123POE",
-    "firstNames": "John",
-    "familyName": "Teal",
-    "dateOfBirth": "2024-10-16"
+    "nomsId": "XX123ABC",
+    "firstNames": "Tamara",
+    "familyName": "Dare",
+    "dateOfBirth": "1990-09-15"
   }]
 }

--- a/src/main/resources/application-seed-test-data.yml
+++ b/src/main/resources/application-seed-test-data.yml
@@ -1,0 +1,3 @@
+spring:
+  flyway:
+    locations: classpath:db/migration,db/seed_test_data

--- a/src/main/resources/db/seed_test_data/V99_1__PPUD_USERS_TEST_DATA.sql
+++ b/src/main/resources/db/seed_test_data/V99_1__PPUD_USERS_TEST_DATA.sql
@@ -1,0 +1,7 @@
+INSERT INTO ppud_users (user_name, ppud_user_full_name, ppud_team_name, ppud_user_name)
+VALUES ('MAKE_RECALL_DECISION_PPCS_USER', 'car test', 'team 1', 'car_test')
+ON CONFLICT (user_name)
+DO UPDATE SET
+	 ppud_user_full_name = 'car test',
+	 ppud_team_name = 'team 1',
+	 ppud_user_name = 'car_test'


### PR DESCRIPTION
Changes to support MRD-2557, e2e local journey tests.

- Add new cypress env values to e2e_local_tests CircleCI job
- Some new wiremock files for PPCS journey
- A new spring profile to seed test data on setup. This is being used here in the local test to ensure we have a PPUD User mapping to retrieve else the attempt to send to PPUD returns a 404 response for failing to find this mapping even though it is only sending to a faked instance.