### PR TITLE
[MRD-2557] Valid test data values

### DIFF
--- a/fake-ppud-automation-api/__files/reference-released-unders.json
+++ b/fake-ppud-automation-api/__files/reference-released-unders.json
@@ -1,6 +1,8 @@
 {
   "values": [
-    "CJA 2023",
-    "Symphony No. 3 \"Eroica\" in E♭ major"
+    "Criminal Law Act 1967",
+    "Criminal Law Act 1977",
+    "Criminal Justice Act 2023",
+    "Crime and Policing Bill"
   ]
 }


### PR DESCRIPTION
Update reference-released-unders to more realistic values that also don't trigger the escape character in options bug in the version of cypress we are currently bound to.

This is because the current version of cypress we are using does not properly escape values with quotation marks but attempting to upgrade our cypress package led to a long road of dependency updates that ended in a an eventual error within one one of these said dependencies.
Seeing as this is only test data and we do not expect this to appear in dev etc and this e2e to work has grown so large due to all of the facets involved, this will solve the immediate issue of this fake data causing issue and reviewing package version will be deferred to it's piece of work to work through the e2e and test and see about cleaning up a lot of the old packages in use.