### PR TITLE
MRD-2721: Consecutive Sentences data

### DIFF
--- a/fake-delius-integration-api/__files/search-cvl-no-additional.json
+++ b/fake-delius-integration-api/__files/search-cvl-no-additional.json
@@ -1,21 +1,11 @@
 {
-  "page": {
-    "size": 10,
-    "number": 0,
-    "totalPages": 1,
-    "totalElements": 1
+  "name": {
+    "forename": "Harry",
+    "surname": "Bloggs"
   },
-  "content": [
-    {
-      "name": {
-        "forename": "Harry",
-        "surname": "Bloggs"
-      },
-      "dateOfBirth": "1980-05-06",
-      "gender": "Male",
-      "identifiers": {
-        "crn": "X098097"
-      }
-    }
-  ]
+  "dateOfBirth": "1980-05-06",
+  "gender": "Male",
+  "identifiers": {
+    "crn": "X098097"
+  }
 }

--- a/fake-delius-integration-api/__files/search-cvl-no-bespoke.json
+++ b/fake-delius-integration-api/__files/search-cvl-no-bespoke.json
@@ -1,21 +1,11 @@
 {
-  "page": {
-    "size": 10,
-    "number": 0,
-    "totalPages": 1,
-    "totalElements": 1
+  "name": {
+    "forename": "Harry",
+    "surname": "Bloggs"
   },
-  "content": [
-    {
-      "name": {
-        "forename": "Harry",
-        "surname": "Bloggs"
-      },
-      "dateOfBirth": "1980-05-06",
-      "gender": "Male",
-      "identifiers": {
-        "crn": "X098096"
-      }
-    }
-  ]
+  "dateOfBirth": "1980-05-06",
+  "gender": "Male",
+  "identifiers": {
+    "crn": "X098096"
+  }
 }

--- a/fake-prison-api/__files/sentences-offences-X098092-12.json
+++ b/fake-prison-api/__files/sentences-offences-X098092-12.json
@@ -28,7 +28,7 @@
         "offenceStartDate": "2018-01-31",
         "offenceStatute": "DD91",
         "offenceCode": "DD91011",
-        "offenceDescription": "(12-1-A) Abandon a fighting dog",
+        "offenceDescription": "Abandon a fighting dog",
         "indicators": [
           "99"
         ]
@@ -38,7 +38,7 @@
         "offenceStartDate": "2018-12-21",
         "offenceStatute": "AN16",
         "offenceCode": "AN16252",
-        "offenceDescription": "(12-1-B) Act as member of flight crew of aircraft without holding appropriate licence",
+        "offenceDescription": "Act as member of flight crew of aircraft without holding appropriate licence",
         "indicators": [
           "99"
         ]
@@ -74,7 +74,7 @@
         "offenceStartDate": "2019-02-25",
         "offenceStatute": "TH68",
         "offenceCode": "TH68058",
-        "offenceDescription": "(12-2-C) Abstract / use without authority electricity",
+        "offenceDescription": "Abstract / use without authority electricity",
         "indicators": [
           "52"
         ]
@@ -84,7 +84,7 @@
         "offenceStartDate": "2018-12-21",
         "offenceStatute": "HT04",
         "offenceCode": "OC01234",
-        "offenceDescription": "(12-C-D) Generic Offence 01234",
+        "offenceDescription": "Generic Offence 01234",
         "indicators": [
           "99"
         ]
@@ -120,7 +120,7 @@
         "offenceStartDate": "2019-02-25",
         "offenceStatute": "TH68",
         "offenceCode": "TH68058",
-        "offenceDescription": "(12-3-Z) Abstract / use without authority electricity",
+        "offenceDescription": "Abstract / use without authority electricity",
         "indicators": [
           "52"
         ]

--- a/fake-prison-api/__files/sentences-offences-X098092-12.json
+++ b/fake-prison-api/__files/sentences-offences-X098092-12.json
@@ -4,6 +4,7 @@
     "sentenceSequence": 1,
     "lineSequence": 1,
     "caseSequence": 1,
+    "consecutiveToSequence": null,
     "courtDescription": "Amersham Crown Court",
     "sentenceStatus": "I",
     "sentenceCategory": "2003",
@@ -27,7 +28,7 @@
         "offenceStartDate": "2018-01-31",
         "offenceStatute": "DD91",
         "offenceCode": "DD91011",
-        "offenceDescription": "Abandon a fighting dog",
+        "offenceDescription": "(12-1-A) Abandon a fighting dog",
         "indicators": [
           "99"
         ]
@@ -37,7 +38,7 @@
         "offenceStartDate": "2018-12-21",
         "offenceStatute": "AN16",
         "offenceCode": "AN16252",
-        "offenceDescription": "Act as member of flight crew of aircraft without holding appropriate licence",
+        "offenceDescription": "(12-1-B) Act as member of flight crew of aircraft without holding appropriate licence",
         "indicators": [
           "99"
         ]
@@ -49,6 +50,7 @@
     "sentenceSequence": 2,
     "lineSequence": 2,
     "caseSequence": 1,
+    "consecutiveToSequence": 1,
     "courtDescription": "Amersham Crown Court",
     "sentenceStatus": "I",
     "sentenceCategory": "2003",
@@ -72,7 +74,7 @@
         "offenceStartDate": "2019-02-25",
         "offenceStatute": "TH68",
         "offenceCode": "TH68058",
-        "offenceDescription": "Abstract / use without authority electricity",
+        "offenceDescription": "(12-2-C) Abstract / use without authority electricity",
         "indicators": [
           "52"
         ]
@@ -82,9 +84,45 @@
         "offenceStartDate": "2018-12-21",
         "offenceStatute": "HT04",
         "offenceCode": "OC01234",
-        "offenceDescription": "Generic Offence 01234",
+        "offenceDescription": "(12-C-D) Generic Offence 01234",
         "indicators": [
           "99"
+        ]
+      }
+    ]
+  },
+  {
+    "bookingId": 12,
+    "sentenceSequence": 3,
+    "lineSequence": 3,
+    "caseSequence": 1,
+    "consecutiveToSequence": null,
+    "courtDescription": "Amersham Crown Court",
+    "sentenceStatus": "I",
+    "sentenceCategory": "2003",
+    "sentenceCalculationType": "EPP",
+    "sentenceTypeDescription": "Extended Sent Public Protection CJA 03",
+    "sentenceDate": "2019-02-01",
+    "sentenceStartDate": "2020-02-01",
+    "sentenceEndDate": "2028-01-31",
+    "terms": [
+      {
+        "years": 8,
+        "months": 6,
+        "weeks": 3,
+        "days": 2,
+        "code": "IMP"
+      }
+    ],
+    "offences": [
+      {
+        "offenderChargeId": 3934355,
+        "offenceStartDate": "2019-02-25",
+        "offenceStatute": "TH68",
+        "offenceCode": "TH68058",
+        "offenceDescription": "(12-3-Z) Abstract / use without authority electricity",
+        "indicators": [
+          "52"
         ]
       }
     ]

--- a/fake-prison-api/__files/sentences-offences-X098092-13.json
+++ b/fake-prison-api/__files/sentences-offences-X098092-13.json
@@ -35,7 +35,7 @@
         "offenceStartDate": "2020-06-12",
         "offenceStatute": "TN51",
         "offenceCode": "TN51010",
-        "offenceDescription": "(13-1-A) Give aid and comfort to the Sovereign's enemies outside his / her realm",
+        "offenceDescription": "Give aid and comfort to the Sovereign's enemies outside his / her realm",
         "indicators": [
           "99"
         ]
@@ -71,7 +71,7 @@
         "offenceStartDate": "2020-06-12",
         "offenceStatute": "CS06",
         "offenceCode": "CS06128",
-        "offenceDescription": "(13-2-F) Fail to have ready for delivery certificate of shares / debentures / debenture stock within 2 months of allotment",
+        "offenceDescription": "Fail to have ready for delivery certificate of shares / debentures / debenture stock within 2 months of allotment",
         "indicators": []
       },
       {
@@ -79,7 +79,7 @@
         "offenceStartDate": "2018-02-10",
         "offenceStatute": "TH68",
         "offenceCode": "TH68047C",
-        "offenceDescription": "(13-2-G) Conspire to commit aggravated burglary with intent - dwelling",
+        "offenceDescription": "Conspire to commit aggravated burglary with intent - dwelling",
         "indicators": [
           "SCH15/CJIB/L",
           "PCSC/SDS+",
@@ -91,7 +91,7 @@
         "offenceStartDate": "2019-10-24",
         "offenceStatute": "FI68",
         "offenceCode": "FI68080",
-        "offenceDescription": "(13-2-H) Have a firearm with intent to resist arrest",
+        "offenceDescription": "Have a firearm with intent to resist arrest",
         "indicators": [
           "99",
           "ERS",
@@ -134,7 +134,7 @@
         "offenceStartDate": "2000-01-01",
         "offenceStatute": "GM00",
         "offenceCode": "GM00030",
-        "offenceDescription": "(13-3-I) Permit an animal to be taken into / upon a Greater Manchester Metrolink vehicle / station without authority",
+        "offenceDescription": "Permit an animal to be taken into / upon a Greater Manchester Metrolink vehicle / station without authority",
         "indicators": []
       }
     ]
@@ -160,7 +160,7 @@
         "offenceStartDate": "1899-01-01",
         "offenceStatute": "SA96",
         "offenceCode": "SA96036",
-        "offenceDescription": "(13-4-J) Attack / assault / batter a member of the public",
+        "offenceDescription": "Attack / assault / batter a member of the public",
         "indicators": []
       }
     ]

--- a/fake-prison-api/__files/sentences-offences-X098092-13.json
+++ b/fake-prison-api/__files/sentences-offences-X098092-13.json
@@ -4,6 +4,7 @@
     "sentenceSequence": 1,
     "lineSequence": 1,
     "caseSequence": 1,
+    "consecutiveToSequence": null,
     "courtDescription": "Durham Crown Court",
     "sentenceStatus": "A",
     "sentenceCategory": "2003",
@@ -34,7 +35,7 @@
         "offenceStartDate": "2020-06-12",
         "offenceStatute": "TN51",
         "offenceCode": "TN51010",
-        "offenceDescription": "Give aid and comfort to the Sovereign's enemies outside his / her realm",
+        "offenceDescription": "(13-1-A) Give aid and comfort to the Sovereign's enemies outside his / her realm",
         "indicators": [
           "99"
         ]
@@ -44,9 +45,9 @@
   {
     "bookingId": 13,
     "sentenceSequence": 2,
-    "consecutiveToSequence": 1,
     "lineSequence": 2,
     "caseSequence": 1,
+    "consecutiveToSequence": 1,
     "courtDescription": "Durham Crown Court",
     "sentenceStatus": "A",
     "sentenceCategory": "2003",
@@ -70,7 +71,7 @@
         "offenceStartDate": "2020-06-12",
         "offenceStatute": "CS06",
         "offenceCode": "CS06128",
-        "offenceDescription": "Fail to have ready for delivery certificate of shares / debentures / debenture stock within 2 months of allotment",
+        "offenceDescription": "(13-2-F) Fail to have ready for delivery certificate of shares / debentures / debenture stock within 2 months of allotment",
         "indicators": []
       },
       {
@@ -78,7 +79,7 @@
         "offenceStartDate": "2018-02-10",
         "offenceStatute": "TH68",
         "offenceCode": "TH68047C",
-        "offenceDescription": "Conspire to commit aggravated burglary with intent - dwelling",
+        "offenceDescription": "(13-2-G) Conspire to commit aggravated burglary with intent - dwelling",
         "indicators": [
           "SCH15/CJIB/L",
           "PCSC/SDS+",
@@ -90,7 +91,7 @@
         "offenceStartDate": "2019-10-24",
         "offenceStatute": "FI68",
         "offenceCode": "FI68080",
-        "offenceDescription": "Have a firearm with intent to resist arrest",
+        "offenceDescription": "(13-2-H) Have a firearm with intent to resist arrest",
         "indicators": [
           "99",
           "ERS",
@@ -109,6 +110,7 @@
     "sentenceSequence": 3,
     "lineSequence": 3,
     "caseSequence": 2,
+    "consecutiveToSequence": 1,
     "courtDescription": "Blackburn County Court",
     "sentenceStatus": "A",
     "sentenceCategory": "2003",
@@ -132,7 +134,7 @@
         "offenceStartDate": "2000-01-01",
         "offenceStatute": "GM00",
         "offenceCode": "GM00030",
-        "offenceDescription": "Permit an animal to be taken into / upon a Greater Manchester Metrolink vehicle / station without authority",
+        "offenceDescription": "(13-3-I) Permit an animal to be taken into / upon a Greater Manchester Metrolink vehicle / station without authority",
         "indicators": []
       }
     ]
@@ -141,7 +143,7 @@
     "bookingId": 13,
     "sentenceSequence": 4,
     "lineSequence": 4,
-    "consecutiveToSequence": 3,
+    "consecutiveToSequence": 2,
     "caseSequence": 2,
     "courtDescription": "Blackburn County Court",
     "sentenceStatus": "A",
@@ -158,7 +160,7 @@
         "offenceStartDate": "1899-01-01",
         "offenceStatute": "SA96",
         "offenceCode": "SA96036",
-        "offenceDescription": "Attack / assault / batter a member of the public",
+        "offenceDescription": "(13-4-J) Attack / assault / batter a member of the public",
         "indicators": []
       }
     ]

--- a/fake-prison-api/__files/sentences-offences-X098092-13.json
+++ b/fake-prison-api/__files/sentences-offences-X098092-13.json
@@ -141,6 +141,7 @@
     "bookingId": 13,
     "sentenceSequence": 4,
     "lineSequence": 4,
+    "consecutiveToSequence": 3,
     "caseSequence": 2,
     "courtDescription": "Blackburn County Court",
     "sentenceStatus": "A",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/controller/PrisonApiController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/controller/PrisonApiController.kt
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.Offender
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PrisonOffenderSearchRequest
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.PrisonSentencesRequest
-import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.Sentence
+import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.SentenceSequence
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.prisonapi.OffenderMovement
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.service.prisonapi.PrisonerApiService
 
@@ -34,7 +34,7 @@ internal class PrisonApiController(
   @Operation(summary = "Returns a list of prison sentences.")
   suspend fun retrieveSentences(
     @RequestBody request: PrisonSentencesRequest,
-  ): List<Sentence> = prisonerApiService.retrieveOffences(request.nomsId)
+  ): List<SentenceSequence> = prisonerApiService.retrieveOffences(request.nomsId)
 
   @PreAuthorize("hasRole('ROLE_MAKE_RECALL_DECISION_PPCS')")
   @GetMapping("/offenders/{nomisId}/movements")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/Sentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/Sentence.kt
@@ -7,6 +7,8 @@ data class Sentence(
   val bookingId: Int? = null,
   val sentenceSequence: Int? = null,
   val lineSequence: Int? = null,
+  val consecutiveToSequence: Int? = null,
+  val consecutiveGroup: List<Int> = listOf(),
   val caseSequence: Int? = null,
   val courtDescription: String? = null,
   val sentenceStatus: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/Sentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/Sentence.kt
@@ -8,7 +8,6 @@ data class Sentence(
   val sentenceSequence: Int? = null,
   val lineSequence: Int? = null,
   val consecutiveToSequence: Int? = null,
-  val consecutiveGroup: List<Int> = listOf(),
   val caseSequence: Int? = null,
   val courtDescription: String? = null,
   val sentenceStatus: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/SentenceSequence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/SentenceSequence.kt
@@ -2,5 +2,5 @@ package uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldeci
 
 data class SentenceSequence(
   val indexSentence: Sentence,
-  val sentencesInSequence: Map<Int, List<Sentence>>? = null,
+  val sentencesInSequence: MutableMap<Int, List<Sentence>>? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/SentenceSequence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/SentenceSequence.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions
+
+data class SentenceSequence(
+  val indexSentence: Sentence,
+  val sentencesInSequence: Map<Int, List<Sentence>>? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/recommendation/NomisIndexOffence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/domain/makerecalldecisions/recommendation/NomisIndexOffence.kt
@@ -9,6 +9,7 @@ data class NomisIndexOffence(
 )
 
 data class OfferedOffence(
+  val consecutiveCount: Int? = null,
   val offenderChargeId: Int? = null,
   val offenceCode: String? = null,
   val offenceStatute: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/prisonapi/PrisonerApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/prisonapi/PrisonerApiService.kt
@@ -115,6 +115,8 @@ internal class PrisonerApiService(
       val sentenceSequenceMap: MutableMap<Int, SentenceSequence> = mutableMapOf()
       // Every index sentence will start a sequence so map a sequence for each index sentence
       indexSentences.forEach {
+        // Should never be null as it make the sentence invalid, however the API contract is nullable
+        // (as are all fields) and so we must defend against this until that may change
         if (it.sentenceSequence != null) {
           sentenceSequenceMap[it.sentenceSequence] = SentenceSequence(it)
         }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/prisonapi/PrisonerApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/prisonapi/PrisonerApiService.kt
@@ -62,12 +62,12 @@ internal class PrisonerApiService(
   /**
    * Sort sentences by first the sentence end date and the by court if there are any with the same date
    */
-  private val sentenceSort: Comparator<Sentence> = compareBy<Sentence> { it.sentenceEndDate }.thenByDescending { it.courtDescription }
+  private val sentenceSort: Comparator<Sentence> = compareByDescending<Sentence> { it.sentenceEndDate }.thenBy { it.courtDescription }
 
   /**
    * Sort sentence sequences by sorting their index sentences by sentenceSort
    */
-  private val sentenceSequenceSort: Comparator<SentenceSequence> = Comparator<SentenceSequence> { a: SentenceSequence, b: SentenceSequence -> sentenceSort.compare(a.indexSentence, b.indexSentence) }
+  private val sentenceSequenceSort: Comparator<SentenceSequence> = Comparator { a: SentenceSequence, b: SentenceSequence -> sentenceSort.compare(a.indexSentence, b.indexSentence) }
 
   /**
    * Retrieve all sequences of sentences and their offences for a nomsId

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/prisonapi/PrisonerApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/prisonapi/PrisonerApiService.kt
@@ -126,8 +126,8 @@ internal class PrisonerApiService(
       // For every consecutiveToSequence (which we know already contains any concurrent for that consecutiveToSequence
       groupedByConsecutiveToSequence.forEach { (consecutiveTo, sentences) ->
         // If the group is consecutive to an index sentence...
-        if (sentenceSequenceMap.keys.contains(consecutiveTo)) {
-          val sequence = sentenceSequenceMap[consecutiveTo]!!
+        if (sentenceSequenceMap.containsKey(consecutiveTo)) {
+          val sequence = sentenceSequenceMap.getValue(consecutiveTo)
           // ...create a new sentencesInSequence map as this must be the first in the chain...
           sentenceSequenceMap[consecutiveTo] = SentenceSequence(sequence.indexSentence, mutableMapOf(consecutiveTo to sentences.sortedWith(sentenceSort)))
         }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/prisonapi/PrisonerApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/prisonapi/PrisonerApiService.kt
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.client.prisonapi.PrisonApiClient
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.Offender
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.Sentence
+import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.SentenceSequence
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.prisonapi.OffenderMovement
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.service.getValueAndHandleWrappedException
@@ -58,64 +59,61 @@ internal class PrisonerApiService(
     return response!!
   }
 
-  fun retrieveOffences(nomsId: String): List<Sentence> {
-    val sentences = ArrayList(
-      getValueAndHandleWrappedException(
-        prisonApiClient.retrievePrisonTimelines(nomsId),
-      )!!.prisonPeriod
-        .flatMap { t ->
-          prisonApiClient.retrieveSentencesAndOffences(t.bookingId).block()!!.map { sentenceAndOffences ->
-            val lastDateOutOfPrison =
-              t.movementDates.map { it.dateOutOfPrison }.filter { it != null }.maxWithOrNull(Comparator.naturalOrder())
-            val movement = t.movementDates.find { it.dateOutOfPrison === lastDateOutOfPrison }
-            val prisonDescription = movement?.releaseFromPrisonId?.let {
-              try {
-                prisonApiClient.retrieveAgency(movement.releaseFromPrisonId).block()?.longDescription
-              } catch (notFoundEx: NotFoundException) {
-                log.info("Agency with id ${movement.releaseFromPrisonId} not found: ${notFoundEx.message}")
-                null
-              }
-            }
-
-            val offender = prisonApiClient.retrieveOffender(nomsId).block()
-            sentenceAndOffences.copy(
-              releaseDate = movement?.dateOutOfPrison,
-              releasingPrison = prisonDescription,
-              licenceExpiryDate = offender?.sentenceDetail?.licenceExpiryDate,
-              offences = sentenceAndOffences.offences.sortedBy { it.offenceDescription },
-            )
+  fun retrieveOffences(nomsId: String): List<SentenceSequence> = getValueAndHandleWrappedException(
+    prisonApiClient.retrievePrisonTimelines(nomsId),
+  )!!.prisonPeriod
+    .flatMap { t ->
+      val sentencesForBooking = prisonApiClient.retrieveSentencesAndOffences(t.bookingId).block()!!.map { sentenceAndOffences ->
+        val lastDateOutOfPrison =
+          t.movementDates.map { it.dateOutOfPrison }.filter { it != null }.maxWithOrNull(Comparator.naturalOrder())
+        val movement = t.movementDates.find { it.dateOutOfPrison === lastDateOutOfPrison }
+        val prisonDescription = movement?.releaseFromPrisonId?.let {
+          try {
+            prisonApiClient.retrieveAgency(movement.releaseFromPrisonId).block()?.longDescription
+          } catch (notFoundEx: NotFoundException) {
+            log.info("Agency with id ${movement.releaseFromPrisonId} not found: ${notFoundEx.message}")
+            null
           }
         }
+
+        val offender = prisonApiClient.retrieveOffender(nomsId).block()
+        sentenceAndOffences.copy(
+          releaseDate = movement?.dateOutOfPrison,
+          releasingPrison = prisonDescription,
+          licenceExpiryDate = offender?.sentenceDetail?.licenceExpiryDate,
+          offences = sentenceAndOffences.offences.sortedBy { it.offenceDescription },
+        )
+      }
         .filter { it.sentenceEndDate == null || !it.sentenceEndDate.isBefore(LocalDate.now()) }
-        .sortedByDescending { it.sentenceEndDate ?: LocalDate.MAX }
-        .sortedBy { it.courtDescription }
-        .sortedByDescending { it.sentenceDate },
-    )
+        .sortedBy { it.sentenceSequence }
 
-    sentences.forEach { sentence ->
-      // If the sentence is consecutive but nothing is consecutive to it, we are at the end of the sequence
-      if (sentence.consecutiveToSequence != null && !sentences.any { s -> s.consecutiveToSequence == sentence.sentenceSequence }) {
-        val consecutiveGroup = ArrayList<Int>()
-        fun buildSequence(consecutiveTo: Int?) {
-          val previousInSequence = sentences.find { s -> s.sentenceSequence == consecutiveTo }
-          if (previousInSequence?.consecutiveToSequence != null) {
-            buildSequence(previousInSequence.consecutiveToSequence)
-            consecutiveGroup.add(previousInSequence.sentenceSequence!!)
-          } else {
-            consecutiveGroup.add(previousInSequence?.sentenceSequence!!)
+      // Sequencing happens here
+      val sequenceList: MutableList<SentenceSequence> = mutableListOf()
+      var currentIndex: Sentence? = null
+      var currentInSequence: MutableMap<Int, MutableList<Sentence>>? = null
+      sentencesForBooking.forEach {
+        if (it.consecutiveToSequence == null) {
+          if (currentIndex != null) {
+            sequenceList.add(SentenceSequence(currentIndex, currentInSequence))
           }
-        }
-        buildSequence(sentence.consecutiveToSequence)
-        consecutiveGroup.add(sentence.sentenceSequence!!)
-        consecutiveGroup.forEach { sentenceSequence ->
-          val sentenceToUpdateIndex = sentences.indexOf(sentences.find { s -> s.sentenceSequence == sentenceSequence })
-          sentences[sentenceToUpdateIndex] = sentences[sentenceToUpdateIndex].copy(consecutiveGroup = consecutiveGroup)
+          currentIndex = it
+          currentInSequence = null
+        } else {
+          if(currentInSequence == null) {
+            currentInSequence = mutableMapOf()
+          }
+          val currentList = currentInSequence[it.consecutiveToSequence] ?: mutableListOf()
+          currentList.add(it)
+          currentInSequence[it.consecutiveToSequence] = currentList
         }
       }
+      if (currentIndex != null) {
+        sequenceList.add(SentenceSequence(currentIndex, currentInSequence))
+      }
+      sequenceList
     }
-
-    return sentences
-  }
+    .sortedByDescending { it.indexSentence.sentenceEndDate ?: LocalDate.MAX }
+    .sortedByDescending { it.indexSentence.sentenceDate }
 
   fun getOffenderMovements(nomsId: String): List<OffenderMovement> {
     log.info("Searching for offender movements for offender with NOMIS ID $nomsId")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/prisonapi/PrisonerApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/prisonapi/PrisonerApiService.kt
@@ -99,7 +99,7 @@ internal class PrisonerApiService(
           currentIndex = it
           currentInSequence = null
         } else {
-          if(currentInSequence == null) {
+          if (currentInSequence == null) {
             currentInSequence = mutableMapOf()
           }
           val currentList = currentInSequence[it.consecutiveToSequence] ?: mutableListOf()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/prisonapi/PrisonerApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/prisonapi/PrisonerApiServiceTest.kt
@@ -502,6 +502,7 @@ internal class PrisonerApiServiceTest {
   val alternativeBookingId = 987
   val defaultBookingCourt = "First Booking Court"
   val alternativeBookingCourt = "Second Booking Court"
+  val testDate = LocalDate.now()
 
   /* This set of sentences is to produce the following SentenceSequences of increasing complexity
    * - { indexSentence: 0, sentencesInSequence: null } Single sentence
@@ -516,12 +517,14 @@ internal class PrisonerApiServiceTest {
       sentenceSequence = 0,
       consecutiveToSequence = null,
       courtDescription = defaultBookingCourt,
+      sentenceEndDate = testDate.plusDays(100),
     ),
     Sentence(
       bookingId = defaultBookingId,
       sentenceSequence = 1,
       consecutiveToSequence = null,
       courtDescription = defaultBookingCourt,
+      sentenceEndDate = testDate.plusDays(99),
     ),
     Sentence(
       bookingId = defaultBookingId,
@@ -534,6 +537,7 @@ internal class PrisonerApiServiceTest {
       sentenceSequence = 3,
       consecutiveToSequence = null,
       courtDescription = defaultBookingCourt,
+      sentenceEndDate = testDate.plusDays(98),
     ),
     Sentence(
       defaultBookingId,
@@ -552,6 +556,7 @@ internal class PrisonerApiServiceTest {
       sentenceSequence = 6,
       consecutiveToSequence = null,
       courtDescription = defaultBookingCourt,
+      sentenceEndDate = testDate.plusDays(97),
     ),
     Sentence(
       defaultBookingId,
@@ -571,6 +576,7 @@ internal class PrisonerApiServiceTest {
       sentenceSequence = 9,
       consecutiveToSequence = null,
       courtDescription = defaultBookingCourt,
+      sentenceEndDate = testDate.plusDays(96),
     ),
     Sentence(
       defaultBookingId,
@@ -588,14 +594,14 @@ internal class PrisonerApiServiceTest {
       defaultBookingId,
       sentenceSequence = 13,
       consecutiveToSequence = 10,
-      sentenceEndDate = LocalDate.now(),
+      sentenceEndDate = testDate,
       courtDescription = alternativeBookingCourt,
     ),
     Sentence(
       defaultBookingId,
       sentenceSequence = 12,
       consecutiveToSequence = 10,
-      sentenceEndDate = LocalDate.now(),
+      sentenceEndDate = testDate,
       courtDescription = defaultBookingCourt,
     ),
     Sentence(
@@ -643,7 +649,7 @@ internal class PrisonerApiServiceTest {
     indexSentence = sentencesForSequencesFirst[9],
     sentencesInSequence = mutableMapOf(
       sentencesForSequencesFirst[9].sentenceSequence!! to listOf(sentencesForSequencesFirst[10], sentencesForSequencesFirst[11]),
-      sentencesForSequencesFirst[10].sentenceSequence!! to listOf(sentencesForSequencesFirst[12], sentencesForSequencesFirst[13]),
+      sentencesForSequencesFirst[10].sentenceSequence!! to listOf(sentencesForSequencesFirst[13], sentencesForSequencesFirst[12]),
     ),
   )
 
@@ -660,14 +666,14 @@ internal class PrisonerApiServiceTest {
       sentenceSequence = 0,
       consecutiveToSequence = null,
       courtDescription = "Second Booking Court",
-      sentenceEndDate = LocalDate.now().plusDays(100),
+      sentenceEndDate = testDate.plusDays(1),
     ),
 
     Sentence(
       bookingId = alternativeBookingId,
       sentenceSequence = 25,
       consecutiveToSequence = 22,
-      sentenceEndDate = LocalDate.now().plusDays(100),
+      sentenceEndDate = testDate.plusDays(1),
     ),
     Sentence(
       bookingId = alternativeBookingId,
@@ -678,7 +684,7 @@ internal class PrisonerApiServiceTest {
       bookingId = alternativeBookingId,
       sentenceSequence = 21,
       consecutiveToSequence = null,
-      sentenceEndDate = LocalDate.now().plusDays(10),
+      sentenceEndDate = testDate.plusDays(10),
     ),
     Sentence(
       bookingId = alternativeBookingId,
@@ -689,7 +695,7 @@ internal class PrisonerApiServiceTest {
       bookingId = alternativeBookingId,
       sentenceSequence = 24,
       consecutiveToSequence = 22,
-      sentenceEndDate = LocalDate.now().plusDays(10),
+      sentenceEndDate = testDate.plusDays(10),
     ),
   )
 


### PR DESCRIPTION
[MRD-2721](https://dsdmoj.atlassian.net/browse/MRD-2721)
Update PrisonApiService to collect consecutiveToSequence for Sentences and calculate the sentences this group each with

[MRD-2721]: https://dsdmoj.atlassian.net/browse/MRD-2721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Note the comment below as our understanding of consecutive/concurrent sentences has evolved since we began this work.
 Additionally, this now incorporates changes to support [MRD-2721](https://dsdmoj.atlassian.net/browse/MRD-2729) as these changes are now inextricably linked.