### PR TITLE
Update fix: paging for search results - by crn vs name

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/OffenderSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/OffenderSearchService.kt
@@ -26,11 +26,11 @@ internal class OffenderSearchService(
       )
     } ?: OffenderSearchResponse()
   } else if (firstName != null && lastName != null) {
-    deliusClient.findByName(firstName, lastName, page, pageSize).let {
+    deliusClient.findByName(firstName, lastName, page - 1, pageSize).let {
       OffenderSearchResponse(
         results = it.content.map { it.toOffenderSearchOffender() },
         paging = Paging(
-          page = it.page.number.toInt(),
+          page = it.page.number.toInt() + 1,
           pageSize = it.page.size.toInt(),
           totalNumberOfPages = it.page.totalPages.toInt(),
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/controller/OffenderSearchControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/controller/OffenderSearchControllerTest.kt
@@ -50,7 +50,7 @@ class OffenderSearchControllerTest(
       findByNameSuccess(crn = crn, firstName = firstName, surname = lastName, dateOfBirth = dateOfBirth)
       val requestBody = OffenderSearchRequest(firstName = firstName, lastName = lastName)
       webTestClient.post()
-        .uri("/paged-search?page=0&pageSize=1")
+        .uri("/paged-search?page=1&pageSize=1")
         .headers { it.authToken(roles = listOf("ROLE_MAKE_RECALL_DECISION")) }
         .body(fromValue(requestBody))
         .exchange()
@@ -69,10 +69,10 @@ class OffenderSearchControllerTest(
       val crn = "A123456"
       val firstName = "test"
       val lastName = "test"
-      val page = Random.Default.nextInt(0, 20)
+      val page = Random.Default.nextInt(1, 19)
       val pageSize = Random.Default.nextInt(1, 10)
-      val totalNumberOfPages = Random.Default.nextInt(page + 1, 20 + 1)
-      findByNameSuccess(crn, firstName, lastName, pageNumber = page, pageSize = pageSize, totalPages = totalNumberOfPages)
+      val totalNumberOfPages = Random.Default.nextInt(page, 20)
+      findByNameSuccess(crn, firstName, lastName, pageNumber = page - 1, pageSize = pageSize, totalPages = totalNumberOfPages)
       val requestBody = OffenderSearchRequest(firstName = firstName, lastName = lastName)
       webTestClient.post()
         .uri("/paged-search?page=$page&pageSize=$pageSize")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/OffenderSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/OffenderSearchServiceTest.kt
@@ -26,13 +26,12 @@ internal class OffenderSearchServiceTest : ServiceTestBase() {
   private lateinit var offenderSearch: OffenderSearchService
 
   private var page = 0
-
   private var pageSize = 0
 
   @BeforeEach
   fun setup() {
     offenderSearch = OffenderSearchService(deliusClient, userAccessValidator)
-    page = Random.Default.nextInt(0, 10)
+    page = Random.Default.nextInt(1, 10)
     pageSize = Random.Default.nextInt(1, 10)
   }
 
@@ -59,7 +58,7 @@ internal class OffenderSearchServiceTest : ServiceTestBase() {
         deliusClient.findByName(
           firstName = nonExistentFirstName,
           surname = nonExistentSurname,
-          page = page,
+          page = page - 1,
           pageSize = pageSize,
         ),
       ).willReturn(CasePage(emptyList(), PagedModel.PageMetadata(0, 0, 0, 0)))
@@ -75,7 +74,7 @@ internal class OffenderSearchServiceTest : ServiceTestBase() {
       then(deliusClient).should().findByName(
         firstName = nonExistentFirstName,
         surname = nonExistentSurname,
-        page = page,
+        page = page - 1,
         pageSize = pageSize,
       )
     }
@@ -85,7 +84,7 @@ internal class OffenderSearchServiceTest : ServiceTestBase() {
   fun `returns search results when searching by CRN`() {
     runTest {
       given(deliusClient.findByCrn(crn = crn))
-        .willReturn(buildSearchPeople1ResultClientResponse(page = page, pageSize = pageSize).content[0])
+        .willReturn(buildSearchPeople1ResultClientResponse(page = page - 1, pageSize = pageSize).content[0])
       given(deliusClient.getUserAccess(username, crn)).willReturn(noAccessLimitations())
 
       val response = offenderSearch.search(crn, page = page, pageSize = pageSize)
@@ -109,10 +108,10 @@ internal class OffenderSearchServiceTest : ServiceTestBase() {
         deliusClient.findByName(
           firstName = firstName,
           surname = lastName,
-          page = page,
+          page = page - 1,
           pageSize = pageSize,
         ),
-      ).willReturn(buildSearchPeople1ResultClientResponse(page = page, pageSize = pageSize))
+      ).willReturn(buildSearchPeople1ResultClientResponse(page = page - 1, pageSize = pageSize))
       given(deliusClient.getUserAccess(username, crn)).willReturn(noAccessLimitations())
 
       val response = offenderSearch.search(firstName = firstName, lastName = lastName, page = page, pageSize = pageSize)
@@ -126,7 +125,7 @@ internal class OffenderSearchServiceTest : ServiceTestBase() {
       then(deliusClient).should().findByName(
         firstName = firstName,
         surname = lastName,
-        page = page,
+        page = page - 1,
         pageSize = pageSize,
       )
     }
@@ -142,12 +141,12 @@ internal class OffenderSearchServiceTest : ServiceTestBase() {
         deliusClient.findByName(
           firstName = firstName,
           surname = lastName,
-          page = page,
+          page = page - 1,
           pageSize = pageSize,
         ),
       ).willReturn(
         buildSearchPeople1ResultClientResponse(
-          page = page,
+          page = page - 1,
           pageSize = pageSize,
           totalPages = totalPages,
         ),


### PR DESCRIPTION
In reaction to the Delius team u[pdating the how we search by crn vs name](https://github.com/ministryofjustice/make-recall-decision-api/commit/06dcdc54d78f666a19e62942a83eaf967d9a6a40#diff-e5a8b7a52df10745443d3d8acda3dbc05d35a84e30253a996f1955a8874960b2L24), the two endpoint differ on their first page index (by crn: 1, by name: 0).

To avoid the UI having to deal with this difference, the UI is moving to "first page = 1" and the API will handle the implementation details of how to communicate this with our downstream dependencies.