### PR TITLE
Handle Delius Search by CRN not found responses

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/client/DeliusClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/client/DeliusClient.kt
@@ -181,7 +181,7 @@ class DeliusClient(
     val primaryLanguage: String?,
 
     val status: Int? = null,
-    val message: String? = null
+    val message: String? = null,
   )
 
   data class PersonalDetailsOverview(
@@ -414,7 +414,7 @@ fun DeliusClient.SearchByCRNResponse.toPersonalDetailsOverview(crn: String): Del
       dateOfBirth = this.dateOfBirth ?: LocalDate.MIN,
       gender = this.gender ?: "",
       this.ethnicity ?: "",
-      primaryLanguage = this.primaryLanguage ?: ""
+      primaryLanguage = this.primaryLanguage ?: "",
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/OffenderSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/OffenderSearchService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.makerecalldecisionapi.service
 
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.client.DeliusClient
+import uk.gov.justice.digital.hmpps.makerecalldecisionapi.client.toPersonalDetailsOverview
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.documentmapper.RecommendationDataToDocumentMapper.Companion.joinToString
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.OffenderSearchOffender
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.domain.makerecalldecisions.OffenderSearchResponse
@@ -21,7 +22,7 @@ internal class OffenderSearchService(
   ): OffenderSearchResponse = if (crn != null) {
     deliusClient.findByCrn(crn)?.let {
       OffenderSearchResponse(
-        results = listOf(it.toOffenderSearchOffender()),
+        results = listOf(it.toPersonalDetailsOverview(crn).toOffenderSearchOffender()),
         paging = Paging(page = 1, pageSize = pageSize, totalNumberOfPages = 1),
       )
     } ?: OffenderSearchResponse()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/IntegrationTestBase.kt
@@ -65,6 +65,7 @@ import uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.responses.
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.responses.ndelius.deliusNoMappaOrRoshHistoryResponse
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.responses.ndelius.deliusRecommendationModelResponse
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.responses.ndelius.deliusRoshHistoryOnlyResponse
+import uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.responses.ndelius.findByCrnNotFoundResponse
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.responses.ndelius.findByCrnResponse
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.responses.ndelius.findByNameResponse
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.responses.ndelius.licenceconditions.licenceResponse
@@ -92,6 +93,7 @@ import java.nio.file.Paths
 import java.sql.DriverManager
 import java.time.LocalDate
 import java.util.concurrent.TimeUnit
+import kotlin.Long
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.integration.responses.ndelius.userResponse as userResponseJson
 
 @AutoConfigureWebTestClient(timeout = "36000")
@@ -687,6 +689,17 @@ abstract class IntegrationTestBase {
       response().withContentType(APPLICATION_JSON)
         .withBody(findByCrnResponse(crn, firstName, surname, dateOfBirth))
         .withDelay(Delay.seconds(delaySeconds)),
+    )
+  }
+
+  protected fun findByCrnNotFound(
+    crn: String = "X123456",
+    delaySeconds: Long = 0
+  ) {
+    deliusIntegration.`when`(request().withPath("/case-summary/$crn")).respond(
+      response().withContentType(APPLICATION_JSON)
+        .withBody(findByCrnNotFoundResponse(crn))
+        .withDelay(Delay.seconds(delaySeconds))
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/IntegrationTestBase.kt
@@ -694,12 +694,12 @@ abstract class IntegrationTestBase {
 
   protected fun findByCrnNotFound(
     crn: String = "X123456",
-    delaySeconds: Long = 0
+    delaySeconds: Long = 0,
   ) {
     deliusIntegration.`when`(request().withPath("/case-summary/$crn")).respond(
       response().withContentType(APPLICATION_JSON)
         .withBody(findByCrnNotFoundResponse(crn))
-        .withDelay(Delay.seconds(delaySeconds))
+        .withDelay(Delay.seconds(delaySeconds)),
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/client/DeliusClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/client/DeliusClientTest.kt
@@ -21,12 +21,24 @@ class DeliusClientTest : IntegrationTestBase() {
     findByCrnSuccess(surname = "Bloggs")
     val response = deliusClient.findByCrn("X123456")
     assertThat(response?.name?.surname).isEqualTo("Bloggs")
+
+    assertThat(response?.status).isNull()
+    assertThat(response?.message).isNull()
   }
 
   @Test
-  fun `find by crn returns null when not found`() {
+  fun `find by crn returns a 404 status response when not found`() {
+    findByCrnNotFound("X123456")
     val response = deliusClient.findByCrn("X123456")
-    assertThat(response).isNull()
+    assertThat(response?.status).isEqualTo(404)
+    assertThat(response?.message).isNotEmpty()
+
+    assertThat(response?.name).isNull()
+    assertThat(response?.identifiers).isNull()
+    assertThat(response?.dateOfBirth).isNull()
+    assertThat(response?.gender).isNull()
+    assertThat(response?.ethnicity).isNull()
+    assertThat(response?.primaryLanguage).isNull()
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/responses/ndelius/FindByCrnResponse.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/responses/ndelius/FindByCrnResponse.kt
@@ -21,7 +21,7 @@ fun findByCrnResponse(
 """.trimIndent()
 
 fun findByCrnNotFoundResponse(
-  crn: String = "X123456"
+  crn: String = "X123456",
 ) = """
 {
   "status": 404,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/responses/ndelius/FindByCrnResponse.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/responses/ndelius/FindByCrnResponse.kt
@@ -19,3 +19,12 @@ fun findByCrnResponse(
   }
 }
 """.trimIndent()
+
+fun findByCrnNotFoundResponse(
+  crn: String = "X123456"
+) = """
+{
+  "status": 404,
+  "message": "Person with CRN of $crn not found"
+}
+""".trimIndent()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/OffenderSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/OffenderSearchServiceTest.kt
@@ -84,7 +84,7 @@ internal class OffenderSearchServiceTest : ServiceTestBase() {
   fun `returns search results when searching by CRN`() {
     runTest {
       given(deliusClient.findByCrn(crn = crn))
-        .willReturn(buildSearchPeople1ResultClientResponse(page = page - 1, pageSize = pageSize).content[0])
+        .willReturn(buildSearchByCRNResponse())
       given(deliusClient.getUserAccess(username, crn)).willReturn(noAccessLimitations())
 
       val response = offenderSearch.search(crn, page = page, pageSize = pageSize)
@@ -165,7 +165,7 @@ internal class OffenderSearchServiceTest : ServiceTestBase() {
   fun `given access is restricted then set user access fields`() {
     runTest {
       given(deliusClient.findByCrn(crn = crn))
-        .willReturn(buildSearchPeople1ResultClientResponse().content[0])
+        .willReturn(buildSearchByCRNResponse())
 
       given(deliusClient.getUserAccess(username, crn)).willReturn(restrictedAccess())
 
@@ -182,7 +182,7 @@ internal class OffenderSearchServiceTest : ServiceTestBase() {
   fun `given user is excluded then set user access fields`() {
     runTest {
       given(deliusClient.findByCrn(crn = crn))
-        .willReturn(buildSearchPeople1ResultClientResponse().content[0])
+        .willReturn(buildSearchByCRNResponse())
 
       given(deliusClient.getUserAccess(username, crn)).willReturn(excludedAccess())
 
@@ -222,7 +222,7 @@ internal class OffenderSearchServiceTest : ServiceTestBase() {
           surname = "Bloggs",
         ),
         dateOfBirth = LocalDate.parse("1982-10-24"),
-        identifiers = DeliusClient.PersonalDetailsOverview.Identifiers(crn = crn, null, null, null, null),
+        identifiers = DeliusClient.Identifiers(crn = crn, null, null, null, null),
         gender = "Male",
         ethnicity = null,
         primaryLanguage = null,
@@ -230,4 +230,21 @@ internal class OffenderSearchServiceTest : ServiceTestBase() {
     ),
     page = PagedModel.PageMetadata(pageSize.toLong(), page.toLong(), 1, totalPages.toLong()),
   )
+
+  private fun buildSearchByCRNResponse() =
+    DeliusClient.SearchByCRNResponse(
+      name = Name(
+        forename = "Joe",
+        middleName = null,
+        surname = "Bloggs",
+      ),
+      dateOfBirth = LocalDate.parse("1982-10-24"),
+      identifiers = DeliusClient.Identifiers(crn = crn, null, null, null, null),
+      gender = "Male",
+      ethnicity = null,
+      primaryLanguage = null,
+      status = null,
+      message = null
+    )
+
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/OffenderSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/OffenderSearchServiceTest.kt
@@ -231,20 +231,18 @@ internal class OffenderSearchServiceTest : ServiceTestBase() {
     page = PagedModel.PageMetadata(pageSize.toLong(), page.toLong(), 1, totalPages.toLong()),
   )
 
-  private fun buildSearchByCRNResponse() =
-    DeliusClient.SearchByCRNResponse(
-      name = Name(
-        forename = "Joe",
-        middleName = null,
-        surname = "Bloggs",
-      ),
-      dateOfBirth = LocalDate.parse("1982-10-24"),
-      identifiers = DeliusClient.Identifiers(crn = crn, null, null, null, null),
-      gender = "Male",
-      ethnicity = null,
-      primaryLanguage = null,
-      status = null,
-      message = null
-    )
-
+  private fun buildSearchByCRNResponse() = DeliusClient.SearchByCRNResponse(
+    name = Name(
+      forename = "Joe",
+      middleName = null,
+      surname = "Bloggs",
+    ),
+    dateOfBirth = LocalDate.parse("1982-10-24"),
+    identifiers = DeliusClient.Identifiers(crn = crn, null, null, null, null),
+    gender = "Male",
+    ethnicity = null,
+    primaryLanguage = null,
+    status = null,
+    message = null,
+  )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/PpcsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/PpcsServiceTest.kt
@@ -24,14 +24,14 @@ internal class PpcsServiceTest : ServiceTestBase() {
   @Test
   fun `excluded records won't be returned`() {
     given(deliusClient.findByCrn("X90902")).willReturn(
-      DeliusClient.PersonalDetailsOverview(
+      DeliusClient.SearchByCRNResponse(
         name = Name(
           forename = "Harry",
           middleName = null,
           surname = "Bloggs",
         ),
         dateOfBirth = LocalDate.now(),
-        identifiers = DeliusClient.PersonalDetailsOverview.Identifiers(
+        identifiers = DeliusClient.Identifiers(
           crn = "X90902",
           nomsNumber = "12345L",
           croNumber = "123/XYZ",
@@ -65,14 +65,14 @@ internal class PpcsServiceTest : ServiceTestBase() {
   @Test
   fun `single active document for ppcs`() {
     given(deliusClient.findByCrn("X90902")).willReturn(
-      DeliusClient.PersonalDetailsOverview(
+      DeliusClient.SearchByCRNResponse(
         name = Name(
           forename = "Harry",
           middleName = null,
           surname = "Bloggs",
         ),
         dateOfBirth = LocalDate.now(),
-        identifiers = DeliusClient.PersonalDetailsOverview.Identifiers(
+        identifiers = DeliusClient.Identifiers(
           crn = "X90902",
           nomsNumber = "12345L",
           croNumber = "123/XYZ",
@@ -111,14 +111,14 @@ internal class PpcsServiceTest : ServiceTestBase() {
   @Test
   fun `do not return results for active recommendation if already been booked`() {
     given(deliusClient.findByCrn("X90902")).willReturn(
-      DeliusClient.PersonalDetailsOverview(
+      DeliusClient.SearchByCRNResponse(
         name = Name(
           forename = "Harry",
           middleName = null,
           surname = "Bloggs",
         ),
         dateOfBirth = LocalDate.now(),
-        identifiers = DeliusClient.PersonalDetailsOverview.Identifiers(
+        identifiers = DeliusClient.Identifiers(
           crn = "X90902",
           nomsNumber = "12345L",
           croNumber = "123/XYZ",
@@ -158,14 +158,14 @@ internal class PpcsServiceTest : ServiceTestBase() {
   @Test
   fun `consider active recommendation only for ppcs search`() {
     given(deliusClient.findByCrn("X90902")).willReturn(
-      DeliusClient.PersonalDetailsOverview(
+      DeliusClient.SearchByCRNResponse(
         name = Name(
           forename = "Harry",
           middleName = null,
           surname = "Bloggs",
         ),
         dateOfBirth = LocalDate.now(),
-        identifiers = DeliusClient.PersonalDetailsOverview.Identifiers(
+        identifiers = DeliusClient.Identifiers(
           crn = "X90902",
           nomsNumber = "12345L",
           croNumber = "123/XYZ",
@@ -213,14 +213,14 @@ internal class PpcsServiceTest : ServiceTestBase() {
   @Test
   fun `do not return results for active recommendation that has not been passed to ppcs`() {
     given(deliusClient.findByCrn("X90902")).willReturn(
-      DeliusClient.PersonalDetailsOverview(
+      DeliusClient.SearchByCRNResponse(
         name = Name(
           forename = "Harry",
           middleName = null,
           surname = "Bloggs",
         ),
         dateOfBirth = LocalDate.now(),
-        identifiers = DeliusClient.PersonalDetailsOverview.Identifiers(
+        identifiers = DeliusClient.Identifiers(
           crn = "X90902",
           nomsNumber = "12345L",
           croNumber = "123/XYZ",
@@ -258,14 +258,14 @@ internal class PpcsServiceTest : ServiceTestBase() {
   @Test
   fun `do not return results for deleted recommendation`() {
     given(deliusClient.findByCrn("X90902")).willReturn(
-      DeliusClient.PersonalDetailsOverview(
+      DeliusClient.SearchByCRNResponse(
         name = Name(
           forename = "Harry",
           middleName = null,
           surname = "Bloggs",
         ),
         dateOfBirth = LocalDate.now(),
-        identifiers = DeliusClient.PersonalDetailsOverview.Identifiers(
+        identifiers = DeliusClient.Identifiers(
           crn = "X90902",
           nomsNumber = "12345L",
           croNumber = "123/XYZ",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/ServiceTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/ServiceTestBase.kt
@@ -11,6 +11,7 @@ import org.springframework.security.core.context.SecurityContextImpl
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.client.CvlApiClient
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.client.DeliusClient
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.client.DeliusClient.Address
+import uk.gov.justice.digital.hmpps.makerecalldecisionapi.client.DeliusClient.Identifiers
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.client.DeliusClient.LicenceConditions
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.client.DeliusClient.LicenceConditions.ConvictionWithLicenceConditions
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.client.DeliusClient.MappaAndRoshHistory
@@ -18,7 +19,6 @@ import uk.gov.justice.digital.hmpps.makerecalldecisionapi.client.DeliusClient.Na
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.client.DeliusClient.Overview
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.client.DeliusClient.PersonalDetails
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.client.DeliusClient.PersonalDetails.Manager
-import uk.gov.justice.digital.hmpps.makerecalldecisionapi.client.DeliusClient.PersonalDetailsOverview.Identifiers
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.client.DeliusClient.RecommendationModel
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.client.DeliusClient.RecommendationModel.ConvictionDetails
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.client.DeliusClient.RecommendationModel.ExtendedSentence


### PR DESCRIPTION
Correct for differing not found response from the delius' `case-sumamry/{crn}` end point.

Following the update to the delius endpoint for searching by CRN, we know get two differently shaped results based on whether a user is found or not.

Not found: ```{ "status": 404, "message": "..." } ```

Found: ```{ "name": { ...} , ...etc }```

In order to contain the change, I have expanded the client to return a `SearchByCRNResponse` which combines both of these onto a single object and then we either detect the 404 and return null (which we previously received for a Not Found result) or reliably cast to the previous PersonalSummaryOverview and continue as we did before.