### PR TITLE
[MRD-2748] Handle search by CRN 404 response

### DIFF
--- a/fake-delius-integration-api/__files/search-not-found.json
+++ b/fake-delius-integration-api/__files/search-not-found.json
@@ -1,0 +1,4 @@
+{
+  "status": 404,
+  "message": "Person with crn of X123456 not found"
+}

--- a/fake-delius-integration-api/mappings/search-not-found.json
+++ b/fake-delius-integration-api/mappings/search-not-found.json
@@ -4,7 +4,7 @@
     "urlPath": "/case-summary/X123456"
   },
   "response": {
-    "status": 400,
+    "status": 404,
     "bodyFileName": "search-not-found.json",
     "headers": {
       "Content-Type": "application/json"

--- a/fake-delius-integration-api/mappings/search-not-found.json
+++ b/fake-delius-integration-api/mappings/search-not-found.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/case-summary/X123456"
+  },
+  "response": {
+    "status": 400,
+    "bodyFileName": "search-not-found.json",
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/client/DeliusClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/client/DeliusClient.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.makerecalldecisionapi.client
 import com.fasterxml.jackson.annotation.JsonFormat
 import io.micrometer.core.instrument.Counter
 import org.apache.commons.lang3.StringUtils.normalizeSpace
-import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.core.io.Resource
@@ -46,8 +45,7 @@ class DeliusClient(
   fun findByCrn(crn: String): PersonalDetailsOverview? {
     val response = try {
       get<PersonalDetailsOverview>("/case-summary/$crn") { Mono.empty() }?.body
-    }
-    catch (_: WebClientResponseException.NotFound) {
+    } catch (_: WebClientResponseException.NotFound) {
       null
     }
     return response

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/IntegrationTestBase.kt
@@ -690,6 +690,20 @@ abstract class IntegrationTestBase {
     )
   }
 
+  protected fun findByCrnNotFound(
+    crn: String = "X123456",
+    firstName: String = "Joe",
+    surname: String = "Bloggs",
+    dateOfBirth: String = "2000-11-09",
+    delaySeconds: Long = 0,
+  ) {
+    deliusIntegration.`when`(request().withPath("/case-summary/$crn")).respond(
+      response().withContentType(APPLICATION_JSON)
+        .withStatusCode(404)
+        .withDelay(Delay.seconds(delaySeconds))
+    )
+  }
+
   protected fun findByNameSuccess(
     crn: String = "Y654321",
     firstName: String = "Joe",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/IntegrationTestBase.kt
@@ -700,7 +700,7 @@ abstract class IntegrationTestBase {
     deliusIntegration.`when`(request().withPath("/case-summary/$crn")).respond(
       response().withContentType(APPLICATION_JSON)
         .withStatusCode(404)
-        .withDelay(Delay.seconds(delaySeconds))
+        .withDelay(Delay.seconds(delaySeconds)),
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/client/DeliusClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/client/DeliusClientTest.kt
@@ -25,7 +25,8 @@ class DeliusClientTest : IntegrationTestBase() {
 
   @Test
   fun `find by crn returns null when not found`() {
-    val response = deliusClient.findByCrn("X123456")
+    findByCrnNotFound(crn = "X654321")
+    val response = deliusClient.findByCrn("X654321")
     assertThat(response).isNull()
   }
 


### PR DESCRIPTION
[MRD-2748]()http://dsdmoj.atlassian.net/browse/MRD-2748)

Delius /case-summary/{crn} now returns a 404 rather than an empty response when not found, handle this and return the already existing null when this occurs.

[MRD-2748]: https://dsdmoj.atlassian.net/browse/MRD-2748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ