### PR TITLE
MRD-2763 Update HMPPS CircleCI orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@7
+  hmpps: ministryofjustice/hmpps@11
   slack: circleci/slack@4.10.1
 
 parameters:


### PR DESCRIPTION
We're upgrading 4 major versions, from 7 to 11:
- 7 > 8 breaking change doesn't affect us: we don't use jira_update
- 8 > 9 breaking change doesn't affect us: we don't use localstack executors
- 9 > 10 breaking change doesn't affect us: this is not an npm project
- 10 > 11 breaking change doesn't affect us: this is not an npm project