### PR TITLE
Template config settings for Preprod/ProdFTR48

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -18,6 +18,9 @@ generic-service:
     MRD_URL: https://make-recall-decision-preprod.hmpps.service.justice.gov.uk
     MRD_API_URL: https://make-recall-decision-api-preprod.hmpps.service.justice.gov.uk
     HOUSEKEEPING_SENDDOMAINEVENTS: true
+    # we cannot override a single item in a list - the whole list is replaced, so we define the whole thing again
+    DOCUMENTTEMPLATE_PARTATEMPLATESETTINGS_0_STARTDATETIME: "2025-07-30T23:45Z"
+    DOCUMENTTEMPLATE_PARTATEMPLATESETTINGS_0_TEMPLATENAME: "NAT Recall Part A London Template - obtained 231114 - v2025-07-29.docx"
 
   scheduledDowntime:
     enabled: true

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -17,6 +17,9 @@ generic-service:
     MRD_URL: https://make-recall-decision.hmpps.service.justice.gov.uk
     MRD_API_URL: https://make-recall-decision-api.hmpps.service.justice.gov.uk
     HOUSEKEEPING_SENDDOMAINEVENTS: true
+    # we cannot override a single item in a list - the whole list is replaced, so we define the whole thing again
+    DOCUMENTTEMPLATE_PARTATEMPLATESETTINGS_0_STARTDATETIME: "2025-07-30T23:45Z"
+    DOCUMENTTEMPLATE_PARTATEMPLATESETTINGS_0_TEMPLATENAME: "NAT Recall Part A London Template - obtained 231114 - v2025-07-29.docx"
 
   postgresDatabaseRestore:
     enabled: true


### PR DESCRIPTION
Set Preprod and Prod document template setting to default to the 'current' template so we can deploy 'as is' until we further develop versioning for recommendations.