### PR TITLE
MRD-2907 Fix OWASP dependency check

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "9.0.2"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "9.1.1"
   kotlin("jvm") version "2.2.20"
   id("org.unbroken-dome.test-sets") version "4.1.0"
   id("jacoco")


### PR DESCRIPTION
OWASP dependency checks were failing due to OSS Index (which OWASP uses by
default) now requiring an API token to be used. The HMPPS gradle plug-in has
been updated to allow setting the token. The OWASP GHA workflow (which we
already use has also been updated accordingly to pass through the
username/token values when set as secrets, and the secrets have been set up
globally for MoJ projects, so just updating the plug-in version should fix the
OWASP issue for us.