### PR TITLE
MRD-3165 fix mappa review status on task list

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/recommendation/RecommendationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/recommendation/RecommendationService.kt
@@ -535,6 +535,7 @@ internal class RecommendationService(
     personOnProbation = deliusDetails.toPersonOnProbation().copy(
       hasBeenReviewed = personOnProbation?.hasBeenReviewed,
       mappa = personOnProbation?.mappa,
+      ftr56MappaReviewed = personOnProbation?.ftr56MappaReviewed,
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/recommendation/RecommendationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/recommendation/RecommendationServiceTest.kt
@@ -81,6 +81,7 @@ import uk.gov.justice.digital.hmpps.makerecalldecisionapi.jpa.entity.Recommendat
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.jpa.entity.RecommendationStatusEntity
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.jpa.entity.Status
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.jpa.entity.TextValueOption
+import uk.gov.justice.digital.hmpps.makerecalldecisionapi.jpa.entity.recommendationEntity
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.mapper.ResourceLoader.CustomMapper
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.service.MrdEventsEmitter
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.service.ServiceTestBase
@@ -1950,6 +1951,67 @@ internal class RecommendationServiceTest : ServiceTestBase() {
       assertThat(expected.dateOfBirth).isEqualTo(actual?.dateOfBirth)
       assertThat(expected.addresses).isEqualTo(actual?.addresses)
       assertThat(expected.firstName).isEqualTo(actual?.firstName)
+    }
+  }
+
+  @Test
+  fun `keeps MAPPA reviewed property when person details from Delius are refreshed`() {
+    runTest {
+      val existingRecommendation = RecommendationEntity(
+        id = 1,
+        data = RecommendationModel(
+          crn = crn,
+          personOnProbation = PersonOnProbation(
+            ftr56MappaReviewed = true,
+          )
+        ),
+      )
+
+      given(recommendationRepository.findById(1L)).willReturn(Optional.of(existingRecommendation))
+
+      val updateRecommendationRequest = MrdTestDataBuilder.updateRecommendationRequestData(existingRecommendation)
+
+      val json = CustomMapper.writeValueAsString(updateRecommendationRequest)
+      val recommendationJsonNode: JsonNode = CustomMapper.readTree(json)
+
+      given(recommendationRepository.save(recommendationCaptor.capture())).willReturn(existingRecommendation)
+      given(deliusClient.getRecommendationModel(anyString())).willReturn(deliusRecommendationModelResponse())
+
+      val expectedRecommendationResponse = RecommendationResponse()
+      given(recommendationConverter.convert(existingRecommendation))
+        .willReturn(expectedRecommendationResponse)
+
+      recommendationService = RecommendationService(
+        recommendationRepository,
+        recommendationStatusRepository,
+        mockPersonDetailService,
+        PrisonerApiService(prisonApiClient, offenderMovementConverter),
+        templateReplacementService,
+        userAccessValidator,
+        RiskService(deliusClient, arnApiClient, userAccessValidator, null, riskScoreConverter),
+        deliusClient,
+        mrdEmitterMocked,
+        recommendationConverter,
+      )
+
+      val actualRecommendationResponse = recommendationService.updateRecommendation(
+        recommendationJsonNode,
+        1L,
+        "bill",
+        "Bill",
+        null,
+        false,
+        false,
+        listOf("personOnProbation"),
+        null
+      )
+
+      assertThat(actualRecommendationResponse).isEqualTo(expectedRecommendationResponse)
+
+      val recommendationEntity = recommendationCaptor.firstValue
+      val actual = recommendationEntity.data.personOnProbation
+
+      assertThat(actual?.ftr56MappaReviewed).isEqualTo(true)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/recommendation/RecommendationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/service/recommendation/RecommendationServiceTest.kt
@@ -1963,7 +1963,7 @@ internal class RecommendationServiceTest : ServiceTestBase() {
           crn = crn,
           personOnProbation = PersonOnProbation(
             ftr56MappaReviewed = true,
-          )
+          ),
         ),
       )
 
@@ -2003,7 +2003,7 @@ internal class RecommendationServiceTest : ServiceTestBase() {
         false,
         false,
         listOf("personOnProbation"),
-        null
+        null,
       )
 
       assertThat(actualRecommendationResponse).isEqualTo(expectedRecommendationResponse)


### PR DESCRIPTION
The bug was basically whenever you review "Personal Details" on the task list it was losing the "reviewed" status of the MAPPA information. This was because the personOnProbation refresh was removing the property saying the MAPPA info had been reviewed, this PR keeps that property intact.