### PR TITLE
MRD-3194: Upgrade to latest gradle spring boot plugin version (9.7.1)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,7 +71,7 @@ dependencies {
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
 
   implementation("com.github.doyaaaaaken:kotlin-csv-jvm:1.10.0")
-  implementation("io.hypersistence:hypersistence-utils-hibernate-63:3.15.2")
+  implementation("io.hypersistence:hypersistence-utils-hibernate-63:3.10.1")
   implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:5.4.6")
   implementation("org.json:json:20250517")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,13 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "9.7.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "9.7.1"
   kotlin("jvm") version "2.3.20"
   id("org.unbroken-dome.test-sets") version "4.1.0"
   id("jacoco")
   kotlin("plugin.jpa") version "2.3.20"
   id("org.sonarqube") version "6.2.0.5505"
-  kotlin("plugin.spring") version "2.3.10"
+  kotlin("plugin.spring") version "2.3.20"
   kotlin("plugin.serialization") version "2.3.20"
 }
 
@@ -45,7 +45,7 @@ dependencies {
     exclude("org.apache.xmlgraphics", "batik-codec")
     exclude("org.apache.xmlgraphics", "batik-transcoder")
     implementation("org.apache.commons:commons-compress:1.27.1") // Address CVE-2024-25710 and CVE-2024-26308 present in v1.21
-    implementation("org.apache.poi:poi-ooxml:5.4.1") // Address CVE-2025-31672 present in 5.2.2
+    implementation("org.apache.poi:poi-ooxml:5.5.1") // Address CVE-2025-31672 present in 5.2.2
   }
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
@@ -55,7 +55,7 @@ dependencies {
 
   implementation("org.flywaydb:flyway-core:11.1.1")
   implementation("org.flywaydb:flyway-database-postgresql:11.1.1")
-  implementation("org.postgresql:postgresql:42.7.7")
+  implementation("org.postgresql:postgresql:42.7.11")
 
   implementation("io.sentry:sentry-spring-boot-starter-jakarta:7.20.0")
   implementation("io.sentry:sentry-logback:7.20.0")
@@ -71,7 +71,7 @@ dependencies {
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
 
   implementation("com.github.doyaaaaaken:kotlin-csv-jvm:1.10.0")
-  implementation("io.hypersistence:hypersistence-utils-hibernate-63:3.10.1")
+  implementation("io.hypersistence:hypersistence-utils-hibernate-63:3.15.2")
   implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:5.4.6")
   implementation("org.json:json:20250517")
 


### PR DESCRIPTION
CVEs fixed as part of this upgrade
 
 CVE-2026-22740,MEDIUM,6.5,Spring Framework 6.2.18,plugin upgrade 9.7.1                                                                                                                                                    
  CVE-2026-22741,LOW,3.1,Spring Framework 6.2.18,plugin upgrade 9.7.1                                                                                                                                                       
  CVE-2026-22745,MEDIUM,5.3,Spring Framework 6.2.18,plugin upgrade 9.7.1                                                                                                                                                    
  CVE-2026-22746,LOW,3.7,Spring Security 6.5.10,plugin upgrade 9.7.1                                                                                                                                                        
  CVE-2026-22748,MEDIUM,6.5,Spring Security 6.5.10,plugin upgrade 9.7.1                                                                                                                                                     
  CVE-2026-22751,MEDIUM,4.8,Spring Security 6.5.10,plugin upgrade 9.7.1                                                                                                                                                     
  CVE-2026-40972,HIGH,7.5,Spring Boot 3.5.14,plugin upgrade 9.7.1                                                                                                                                                         
  CVE-2026-40973,HIGH,7.0,Spring Boot 3.5.14,plugin upgrade 9.7.1                                                                                                                                                           
  CVE-2026-40975,HIGH,7.5,Spring Boot 3.5.14,plugin upgrade 9.7.1                                                                                                                                                           
  CVE-2026-40977,MEDIUM,6.7,Spring Boot 3.5.14,plugin upgrade 9.7.1                                                                                                                                                         
  CVE-2026-42198,HIGH,7.5,postgresql 42.7.11,postgresql bump                                                                                                                                                
                                                                                                                                                                                                                          
  11 CVEs fixed in total - 3 HIGH, 5 MEDIUM, 2 LOW - across the plugin upgrade and the postgresql bump.  