### PR TITLE
MRD-3158 Fix buffer config size

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,8 @@ spring:
   http:
     converters:
       preferred-json-mapper: jackson2
+    codecs:
+      max-in-memory-size: 30MB
   flyway:
   jpa:
     properties:
@@ -17,8 +19,6 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
   application:
     name: make-recall-decision-api
-  codec:
-    max-in-memory-size: 30MB
   security:
     oauth2:
       client:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/client/DeliusClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/makerecalldecisionapi/integration/client/DeliusClientTest.kt
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.client.DeliusClient
+import uk.gov.justice.digital.hmpps.makerecalldecisionapi.client.contact
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.client.contactHistory
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.client.toJsonString
 import uk.gov.justice.digital.hmpps.makerecalldecisionapi.exception.ClientTimeoutException
@@ -141,6 +142,43 @@ class DeliusClientTest : IntegrationTestBase() {
       )
 
     val contactHistory = contactHistory()
+    deliusIntegration.`when`(contactHistoryRequest).respond(
+      response().withContentType(APPLICATION_JSON)
+        .withBody(
+          contactHistory.toJsonString(),
+        ),
+    )
+
+    // when
+    val response = deliusClient.getContactHistory(crn)
+
+    // then
+    assertThat(response).isEqualTo(contactHistory)
+  }
+
+  @Test
+  fun `get contact history when no filtering options specified - large response`() {
+    // this test checks we're able to handle large responses, including not overloading the buffer (we have had
+    // config issues around this)
+
+    // given
+    val crn = randomString()
+
+    val contactHistoryRequest = request()
+      .withPath("/case-summary/$crn/contact-history")
+      .withQueryStringParameters(
+        mapOf(
+          "query" to emptyList<String>(),
+          "from" to emptyList<String>(),
+          "to" to emptyList<String>(),
+          "type" to emptyList<String>(),
+          "includeSystemGenerated" to listOf("true"),
+        ),
+      )
+
+    val contactHistory = contactHistory(
+      contacts = List(10000) { contact() },
+    )
     deliusIntegration.`when`(contactHistoryRequest).respond(
       response().withContentType(APPLICATION_JSON)
         .withBody(


### PR DESCRIPTION
The spring.codec.max-in-memory-size configuration option was moved to
spring.http.codecs.max-in-memory-size with Spring Boot 3.5.0 and marked as
deprecated:
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.5.0-RC1-Release-Notes#deprecations-in-spring-boot-350-rc1
The old option was removed with Spring Boot 4. Updating it accordingly here.