### PR TITLE
Fix pipeline

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -51,6 +51,7 @@ jobs:
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/docker_build.yml@v2
     needs:
       - kotlin_validate
+      - e2e_local_tests
     with:
       docker_registry: 'ghcr.io'
       registry_org: 'ministryofjustice'


### PR DESCRIPTION
The e2e_local_tests step had been missed out when setting the build step's
requirements. We don't want the image built until we confirm all tests are
running successfully (and more importantly because we don't want to deploy into
dev or be able to deploy into prod without the local e2e tests passing).