### PR TITLE
Fix few CVEs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,29 @@ configurations {
     // Force json-unit-core back to the version MockServer was built against.
     resolutionStrategy.force("net.javacrumbs.json-unit:json-unit-core:2.36.0")
   }
+  // CVE version overrides - the hmpps-gradle-spring-boot plugin uses resolution rules that
+  // override BOM constraints, so we must use eachDependency to force specific versions.
+  // These can be removed once the plugin is upgraded to 11.0.x
+  all {
+    resolutionStrategy.eachDependency {
+      if (requested.group == "io.netty" && requested.name.startsWith("netty-") && !requested.name.startsWith("netty-tcnative")) {
+        useVersion("4.2.16.Final")
+        because("Address CVE-2026-44891, CVE-2026-55831, CVE-2026-55833 and other Netty CVEs")
+      }
+      if (requested.group == "org.apache.logging.log4j") {
+        useVersion("2.26.1")
+        because("Address CVE-2026-49844")
+      }
+      if (requested.group == "com.fasterxml.jackson.core" && requested.name == "jackson-databind") {
+        useVersion("2.22.1")
+        because("Address CVE-2026-54515 and CVE-2026-59889")
+      }
+      if (requested.group == "tools.jackson.core" && requested.name == "jackson-databind") {
+        useVersion("3.1.5")
+        because("Address CVE-2026-59889")
+      }
+    }
+  }
 }
 
 dependencyCheck {
@@ -64,12 +87,11 @@ dependencies {
   implementation("io.sentry:sentry-logback:8.42.0")
 
   // OpenAPI dependencies
-  // Not sure if we're affected, but release notes on 10.2.1 version of hmpps-gradle-spring-boot
-  // reported some issues encountered and recommended pinning swagger-ui to 5.32.2 and not updating
-  // the springdoc dependency for now
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3")
   constraints {
-    implementation("org.webjars:swagger-ui:5.32.2")
+    implementation("org.webjars:swagger-ui:5.32.7") {
+      because("Address DOMPurify CVEs (CVE-2026-65898 through CVE-2026-66010) - bundles DOMPurify 3.4.11")
+    }
   }
 
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
@@ -88,8 +110,8 @@ dependencies {
   implementation("net.javacrumbs.shedlock:shedlock-provider-jdbc-template:6.10.0")
 
   constraints {
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.21.5") {
-      because("Address CVE-2026-54515 - can be removed once hmpps-kotlin-spring-boot-starter has a new version addressing this and hmpps-sqs-spring-boot-starter upgraded to v7")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.22.1") {
+      because("Address CVE-2026-54515 and CVE-2026-59889 - can be removed once hmpps-kotlin-spring-boot-starter has a new version addressing this and hmpps-sqs-spring-boot-starter upgraded to v7")
     }
     implementation("org.springframework.retry:spring-retry:2.0.13") {
       because("Address CVE-2026-41710 - can be removed once hmpps-sqs-spring-boot-starter upgraded to v7")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -102,10 +102,10 @@ springdoc:
     enabled: false
   swagger-ui:
     enabled: false
-    # Temporarily set when org.webjars:swagger-ui was set to 5.32.2 in build.gradle, as otherwise swagger-ui doesn't work.
+    # Temporarily set when org.webjars:swagger-ui was set to 5.32.7 in build.gradle, as otherwise swagger-ui doesn't work.
     # Seems to be used in some places to build the path from which to retrieve resources, although it isn't officially
     # documented :/. Remove whenever no longer needed
-    version: 5.32.2
+    version: 5.32.7
 
 server:
   port: 8080


### PR DESCRIPTION
                                                                                                                                                                                                      
  BEFORE (117 vulnerabilities, build failed)                                                                                                                                                            
                                                                                                                                                                                                        
  > Task :dependencyCheckAnalyze                                                                                                                                                                        
  Found 117 vulnerabilities in project make-recall-decision-api                                                                                                                                       

  HdrHistogram-2.2.2.jar : CVE-2026-14683, CVE-2026-14686                                                                                                                                               
  jackson-databind-2.22.0.jar : CVE-2026-59889, CVE-2026-54515
  jackson-databind-3.1.4.jar : CVE-2026-59889                                                                                                                                                           
  log4j-api-2.25.4.jar : CVE-2026-49844                                                                                                                                                               
  log4j-to-slf4j-2.25.4.jar : CVE-2026-49844                                                                                                                                                            
  netty-buffer-4.2.15.Final.jar : CVE-2026-44891, CVE-2026-55831, CVE-2026-55833                                                                                                                      
  netty-codec-4.2.15.Final.jar : CVE-2026-44891, CVE-2026-55831, CVE-2026-55833                                                                                                                         
  netty-codec-base-4.2.15.Final.jar : CVE-2026-44891, CVE-2026-55831, CVE-2026-55833                                                                                                                  
  netty-codec-classes-quic-4.2.15.Final.jar : CVE-2026-44891, CVE-2026-55831, CVE-2026-55833                                                                                                            
  netty-codec-compression-4.2.15.Final.jar : CVE-2026-59901, CVE-2026-44891, CVE-2026-55831, CVE-2026-55833                                                                                             
  netty-codec-dns-4.2.15.Final.jar : CVE-2026-44891, CVE-2026-55831, CVE-2026-55833                                                                                                                     
  netty-codec-http-4.2.15.Final.jar : CVE-2026-56745, CVE-2026-44891, CVE-2026-55831, CVE-2026-55833, CVE-2026-59899, CVE-2026-56746, CVE-2026-59898, CVE-2026-59921                                    
  netty-codec-http2-4.2.15.Final.jar : CVE-2026-44891, CVE-2026-55831, CVE-2026-55833, CVE-2026-56819, CVE-2026-59900                                                                                   
  netty-codec-http3-4.2.15.Final.jar : CVE-2026-44891, CVE-2026-55831, CVE-2026-55833                                                                                                                   
  netty-codec-marshalling-4.2.15.Final.jar : CVE-2026-44891, CVE-2026-55831, CVE-2026-55833                                                                                                             
  netty-codec-native-quic-4.2.15.Final-linux-aarch_64.jar : CVE-2026-44891, CVE-2026-55831, CVE-2026-55833                                                                                              
  netty-codec-native-quic-4.2.15.Final-linux-x86_64.jar : CVE-2026-44891, CVE-2026-55831, CVE-2026-55833                                                                                                
  netty-codec-native-quic-4.2.15.Final-osx-aarch_64.jar : CVE-2026-44891, CVE-2026-55831, CVE-2026-55833                                                                                                
  netty-codec-native-quic-4.2.15.Final-osx-x86_64.jar : CVE-2026-44891, CVE-2026-55831, CVE-2026-55833                                                                                                  
  netty-codec-native-quic-4.2.15.Final-windows-x86_64.jar : CVE-2026-44891, CVE-2026-55831, CVE-2026-55833                                                                                              
  netty-codec-protobuf-4.2.15.Final.jar : CVE-2026-44891, CVE-2026-55831, CVE-2026-55833                                                                                                                
  netty-codec-socks-4.2.15.Final.jar : CVE-2026-44891, CVE-2026-55831, CVE-2026-55833                                                                                                                   
  netty-common-4.2.15.Final.jar : CVE-2026-44891, CVE-2026-55831, CVE-2026-55833                                                                                                                        
  netty-handler-4.2.15.Final.jar : CVE-2026-44891, CVE-2026-55831, CVE-2026-55833                                                                                                                       
  netty-handler-proxy-4.2.15.Final.jar : CVE-2026-44891, CVE-2026-55831, CVE-2026-55833                                                                                                                 
  netty-resolver-4.2.15.Final.jar : CVE-2026-44891, CVE-2026-55831, CVE-2026-55833                                                                                                                      
  netty-resolver-dns-4.2.15.Final.jar : CVE-2026-44891, CVE-2026-55831, CVE-2026-55833                                                                                                                  
  netty-resolver-dns-classes-macos-4.2.15.Final.jar : CVE-2026-44891, CVE-2026-55831, CVE-2026-55833                                                                                                    
  netty-resolver-dns-native-macos-4.2.15.Final-osx-aarch_64.jar : CVE-2026-44891, CVE-2026-55831, CVE-2026-55833                                                                                        
  netty-resolver-dns-native-macos-4.2.15.Final-osx-x86_64.jar : CVE-2026-44891, CVE-2026-55831, CVE-2026-55833                                                                                          
  netty-transport-4.2.15.Final.jar : CVE-2026-44891, CVE-2026-55831, CVE-2026-55833                                                                                                                     
  netty-transport-classes-epoll-4.2.15.Final.jar : CVE-2026-44891, CVE-2026-55831, CVE-2026-55833                                                                                                       
  netty-transport-native-epoll-4.2.15.Final-linux-x86_64.jar : CVE-2026-44891, CVE-2026-55831, CVE-2026-55833                                                                                           
  netty-transport-native-unix-common-4.2.15.Final.jar : CVE-2026-44891, CVE-2026-55831, CVE-2026-55833                                                                                                  
  spring-cloud-aws-sns-3.4.2.jar : CVE-2026-44308                                                                                                                                                       
  swagger-ui-5.32.2.jar: swagger-ui-bundle.js (DOMPurify@3.3.2) : CVE-2026-65898, CVE-2026-65902, CVE-2026-65903, CVE-2026-65899, CVE-2026-65900, CVE-2026-65901, CVE-2026-66010                        
  swagger-ui-5.32.2.jar: swagger-ui-es-bundle.js (DOMPurify@3.3.2) : CVE-2026-65898, CVE-2026-65902, CVE-2026-65903, CVE-2026-65899, CVE-2026-65900, CVE-2026-65901, CVE-2026-66010                     
                                                                                                                                                                                                        
  Dependency-Analyze Failure:                                                                                                                                                                           
  One or more dependencies were identified with vulnerabilities that have a CVSS score greater than '5.0':                                                                                              
  CVE-2026-54515, CVE-2026-55833, CVE-2026-56746, CVE-2026-56819, CVE-2026-59899, CVE-2026-59921,                                                                                                       
  CVE-2026-59889, CVE-2026-59900, CVE-2026-59901, CVE-2026-55831, CVE-2026-56745, CVE-2026-59898,                                                                                                       
  CVE-2026-65898, CVE-2026-65903, CVE-2026-65902, CVE-2026-44308, CVE-2026-44891, CVE-2026-49844                                                                                                        
                                                                                                                                                                                                        
  BUILD FAILED                                                                                                                                                                                          
                                                                                                                                                                                                        
  AFTER (5 vulnerabilities remaining — no fix available for any)                                                                                                                                        
   
  > Task :dependencyCheckAnalyze                                                                                                                                                                        
  Found 5 vulnerabilities in project make-recall-decision-api                                                                                                                                         

  HdrHistogram-2.2.2.jar : CVE-2026-14683, CVE-2026-14686                                                                                                                                               
  spring-cloud-aws-sns-3.4.2.jar : CVE-2026-44308
  swagger-ui-5.32.7.jar: swagger-ui-bundle.js (DOMPurify@3.4.11) : CVE-2026-66010                                                                                                                       
  swagger-ui-5.32.7.jar: swagger-ui-es-bundle.js (DOMPurify@3.4.11) : CVE-2026-66010                                                                                                                    
                                                                                                                                                                                                        
  Dependency-Analyze Failure:                                                                                                                                                                           
  One or more dependencies were identified with vulnerabilities that have a CVSS score greater than '5.0':                                                                                              
  CVE-2026-44308                                                                                                                                                                                      
                                                                                                                                                                                                        
  BUILD FAILED
                                                                                                                                                                                                        
117 -> 5 vulnerabilities. 18 -> 1 high-severity (CVSS > 5.0). 
The remaining 5 have no upstream fix available.   